### PR TITLE
fix: select shows 'unknown' + alert_id breaks on special chars

### DIFF
--- a/custom_components/emergency_alerts/config_flow.py
+++ b/custom_components/emergency_alerts/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import voluptuous as vol
@@ -10,6 +11,18 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
+
+
+def _slugify_alert_id(name: str) -> str:
+    """Derive a clean alert_id from a display name.
+
+    Strips/collapses non-alphanumeric characters so names like
+    "Smoke/CO Detector (Triggered)" don't produce alert_ids with
+    slashes or parens (which break remove_alert lookups and pollute
+    entity_id derivation).
+    """
+    slug = re.sub(r"[^a-z0-9_]+", "_", name.lower()).strip("_")
+    return re.sub(r"_+", "_", slug)
 
 from .const import (
     DOMAIN,
@@ -137,7 +150,7 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
 
         if user_input is not None:
             try:
-                alert_id = user_input["name"].lower().replace(" ", "_")
+                alert_id = _slugify_alert_id(user_input["name"])
                 alerts = dict(self.config_entry.data.get(CONF_ALERTS, {}))
 
                 if alert_id in alerts:

--- a/custom_components/emergency_alerts/select.py
+++ b/custom_components/emergency_alerts/select.py
@@ -17,6 +17,7 @@ from .const import (
     STATE_INACTIVE,
     STATE_ACKNOWLEDGED,
     STATE_SNOOZED,
+    STATE_ESCALATED,
     STATE_RESOLVED,
     DEFAULT_SNOOZE_DURATION,
     SIGNAL_ALERT_UPDATE,
@@ -27,11 +28,17 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Available states for the select entity
+# Available states for the select entity. Includes INACTIVE and ESCALATED so the
+# select widget can display a meaningful current value when the alert is not
+# firing (INACTIVE) or has escalated past its ack window (ESCALATED). Previously
+# the sync logic set _attr_current_option to STATE_INACTIVE when the alert was
+# off, but since "inactive" wasn't in this list, the select rendered "unknown".
 ALERT_STATES = [
+    STATE_INACTIVE,
     STATE_ACTIVE,
     STATE_ACKNOWLEDGED,
     STATE_SNOOZED,
+    STATE_ESCALATED,
     STATE_RESOLVED,
 ]
 


### PR DESCRIPTION
## Summary

Two related quality-of-life bugs surfaced while bulk-provisioning alerts via the `config_entries/options/flow` REST API. Both are short, surgical fixes.

### Bug 1: `select.<alert>_state` shows "unknown" when alert is off

`select.py` defined `ALERT_STATES = [STATE_ACTIVE, STATE_ACKNOWLEDGED, STATE_SNOOZED, STATE_RESOLVED]` — missing `STATE_INACTIVE` (and `STATE_ESCALATED`). But `_sync_state_from_binary_sensor()` at line 122 sets `_attr_current_option = STATE_INACTIVE` when the alert binary sensor is off. Since `inactive` wasn't in `_attr_options`, HA's `SelectEntity` widget rendered the current value as **"unknown"**.

After: when no alert is firing, the select reads "inactive". When the escalation timer fires, it reads "escalated". Both states were already supported by `const.py` and the state machine — this just makes them visible.

### Bug 2: `alert_id` preserved special characters from display name

```python
alert_id = user_input["name"].lower().replace(" ", "_")
```

Only space → underscore. Slashes, parens, plus signs were preserved. So `"Smoke/CO Triggered"` → `smoke/co_triggered` and `"Home Compromised (Vacation Mode)"` → `home_compromised_(vacation_mode)`. These weird alert_ids:
- Break `remove_alert` lookups (the form schema validates `alert_id` is in the existing list, and humans don't remember parens)
- Pollute downstream `entity_id` derivation

Replaced with a regex helper `_slugify_alert_id()` that strips non-`[a-z0-9_]` and collapses repeats.

## Backwards compatibility

- Existing alerts retain their stored `alert_id` keys — no migration needed.
- Existing `select.<alert>_state` entities pick up the wider option list on next integration reload.
- New alerts created after merge get cleaner sanitization automatically.

## Test plan

- [x] `python3 -m py_compile` both files
- [x] Standalone test of `_slugify_alert_id` on 9 representative inputs (External Door Open, Smoke/CO Triggered, Home Compromised (Vacation Mode), Rain + Windows Open, UPS Critical (Outage), Critical Sensor Stale (>24h), multiple spaces, leading/trailing spaces, 1080p Movie) — all produce expected slugs.
- [x] All `STATE_*` constants required by select.py are present in const.py
- [ ] Run unit tests in `custom_components/emergency_alerts/tests/unit/test_state_machine.py` against this branch (no venv in dev env at time of authoring)
- [ ] Confirm in HA UI: a freshly-loaded alert with binary_sensor=off shows `select.<alert>_state = inactive` instead of `unknown`

## Context

Found during expansion from 2 → 21 alerts across 5 hubs in @issmirnov's home setup. Full bug log of v4.1.0 issues at `~/.claude/projects/-home-vania-Projects-1-Personal-hassio/memory/feedback_emergency_alerts_integration_bugs.md` — this PR addresses 2 of the 6 documented bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)