### PR TITLE
fix: template-trigger alerts re-evaluate on referenced-entity changes

### DIFF
--- a/custom_components/emergency_alerts/binary_sensor.py
+++ b/custom_components/emergency_alerts/binary_sensor.py
@@ -7,7 +7,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later, async_track_state_change_event
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_state_change_event,
+    async_track_template_result,
+    TrackTemplate,
+)
 from homeassistant.helpers.template import Template
 import yaml
 
@@ -272,30 +277,52 @@ class EmergencyBinarySensor(BinarySensorEntity):
         # Register cleanup callback when entity is properly added to hass
         self.async_on_remove(self._cleanup_timers)
         
-        # Track all referenced entities for state changes
-        entities = set()
-        if self._trigger_type == "simple" and self._entity_id:
-            entities.add(self._entity_id)
-        elif self._trigger_type == "logical" and self._logical_conditions:
-            for cond in self._logical_conditions:
-                if isinstance(cond, dict) and "entity_id" in cond:
-                    entities.add(cond["entity_id"])
-        # For template, we can't know all entities, so listen to all changes
-        if self._trigger_type == "template":
-            entities = None
-
+        # Track referenced entities so the trigger re-evaluates when they change.
         @callback
         def state_change(event):
             self._evaluate_trigger()
 
-        if entities:
-            self._unsub = async_track_state_change_event(
-                self.hass, list(entities), state_change
+        if self._trigger_type == "template" and self._template:
+            # Template triggers must use async_track_template_result so HA
+            # subscribes to the entities the Jinja actually references — not
+            # just an explicit entity_id field on the alert. Previously this
+            # branch called async_track_state_change_event(hass, [], ...) with
+            # an empty entity list, which subscribes to nothing and causes
+            # template alerts to never re-evaluate after their initial render
+            # (so they latch on/off until integration reload).
+            template = Template(self._template, self.hass)
+
+            @callback
+            def template_result_change(event, updates):
+                self._evaluate_trigger()
+
+            info = async_track_template_result(
+                self.hass,
+                [TrackTemplate(template, None)],
+                template_result_change,
             )
+            self._unsub = info.async_remove
+            # Kick off the initial async render so HA registers the listener
+            # against the discovered entities.
+            info.async_refresh()
         else:
-            # Listen to all state changes for template triggers
-            self._unsub = async_track_state_change_event(
-                self.hass, [], state_change)
+            # simple + logical triggers: derive the explicit entity list.
+            entities: set[str] = set()
+            if self._trigger_type == "simple" and self._entity_id:
+                entities.add(self._entity_id)
+            elif self._trigger_type == "logical" and self._logical_conditions:
+                for cond in self._logical_conditions:
+                    if isinstance(cond, dict) and "entity_id" in cond:
+                        entities.add(cond["entity_id"])
+
+            if entities:
+                self._unsub = async_track_state_change_event(
+                    self.hass, list(entities), state_change
+                )
+            else:
+                # No entities to watch (logical with no entity_ids, or an
+                # otherwise unconfigured alert) — leave the listener unset.
+                self._unsub = None
 
         # Listen for switch updates (switches will broadcast their state changes)
         self.async_on_remove(

--- a/custom_components/emergency_alerts/tests/integration/test_template_trigger_rerender.py
+++ b/custom_components/emergency_alerts/tests/integration/test_template_trigger_rerender.py
@@ -1,0 +1,89 @@
+"""Regression test for bug 7: template-trigger alerts must re-evaluate on state changes.
+
+Before the fix, ``async_track_state_change_event(hass, [], state_change)`` was
+called with an empty entity list for template triggers, which subscribes to
+nothing. Template alerts then never re-evaluated and would latch on/off until
+the next integration reload.
+
+The fix replaces that with ``async_track_template_result`` which subscribes to
+the entities referenced inside the Jinja template.
+"""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.emergency_alerts.const import DOMAIN
+
+
+@pytest.fixture
+async def template_alert_hub(hass: HomeAssistant):
+    """Hub with one template-trigger alert that watches an external sensor."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Emergency Alerts - Template Group",
+        data={
+            "hub_type": "group",
+            "group": "test",
+            "hub_name": "test_template_hub",
+            "alerts": {
+                "rerender_alert": {
+                    "name": "Rerender Alert",
+                    "trigger_type": "template",
+                    "template": "{{ states('sensor.watched_value') | float(0) > 50 }}",
+                    "severity": "warning",
+                },
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # Seed the watched entity below threshold before setup so the alert
+    # starts in the off state.
+    hass.states.async_set("sensor.watched_value", "10")
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+@pytest.mark.integration
+async def test_template_trigger_reevaluates_on_referenced_entity_change(
+    hass: HomeAssistant, template_alert_hub
+):
+    """Bug 7: template alerts should flip on/off when the watched entity changes.
+
+    Before the fix, this test would fail because async_track_state_change_event
+    was passed an empty entity list, so the binary_sensor never re-evaluated.
+    """
+    # Find the alert entity (entity_id format varies across branches — clean
+    # form lands in PR #13). Match by name fragment to be robust.
+    candidates = [
+        s.entity_id
+        for s in hass.states.async_all()
+        if s.entity_id.startswith("binary_sensor.") and "rerender_alert" in s.entity_id
+    ]
+    assert candidates, (
+        f"No rerender_alert binary_sensor found. All entities: "
+        f"{[s.entity_id for s in hass.states.async_all()]}"
+    )
+    alert = candidates[0]
+
+    # Initial state: watched=10 (below 50) so alert is off.
+    assert hass.states.get(alert).state == "off"
+
+    # Move watched value above threshold — alert should flip ON.
+    hass.states.async_set("sensor.watched_value", "75")
+    await hass.async_block_till_done()
+    assert hass.states.get(alert).state == "on", (
+        "Template alert did not re-evaluate when its referenced entity changed. "
+        "Bug 7 regressed."
+    )
+
+    # Move back below threshold — alert should flip OFF again.
+    hass.states.async_set("sensor.watched_value", "25")
+    await hass.async_block_till_done()
+    assert hass.states.get(alert).state == "off", (
+        "Template alert did not re-evaluate on second change. Bug 7 regressed."
+    )


### PR DESCRIPTION
## TL;DR

Template-trigger alerts never re-evaluate after their initial render — they latch on/off until the integration reloads. Replace `async_track_state_change_event(hass, [], ...)` (which subscribes to nothing) with `async_track_template_result` (which subscribes to the entities the Jinja actually references).

## The bug

`binary_sensor.py:296-298` for template triggers calls:

```python
self._unsub = async_track_state_change_event(self.hass, [], state_change)
```

The intent (per the inline comment) was "Listen to all state changes for template triggers" — but HA's `async_track_state_change_event` with an **empty list** subscribes to **nothing**. It doesn't fall back to "watch everything." So every template alert in the integration silently never re-evaluates after the initial render.

## Live impact

Observed 2026-05-26 in a production deployment with 21 alerts (12 template-triggered):

- `binary_sensor.emergency_ups_warning` fired during HACS reload when `sensor.rack_ups_status` was momentarily `unavailable`
- Both UPS sensors then returned to `Online` / 100% battery within seconds
- The template evaluated `False`, but the alert stayed `on` for 5+ hours
- Internal escalation timer ran; status moved to `escalated`
- Required manual `select.select_option: resolved` to clear

This is a **silent latch bug**: every template alert that fires once stays on until reload, regardless of whether the underlying condition is still true.

## The fix

Use `async_track_template_result` with `TrackTemplate`. HA parses the Jinja, finds referenced entities, and subscribes only to those.

```python
if self._trigger_type == "template" and self._template:
    template = Template(self._template, self.hass)

    @callback
    def template_result_change(event, updates):
        self._evaluate_trigger()

    info = async_track_template_result(
        self.hass,
        [TrackTemplate(template, None)],
        template_result_change,
    )
    self._unsub = info.async_remove
    info.async_refresh()
```

Simple + logical triggers keep the existing `async_track_state_change_event` path (they have explicit entity lists, which work correctly).

## Test plan

New regression test `tests/integration/test_template_trigger_rerender.py`:

1. Sets up a template alert watching `sensor.watched_value > 50`
2. Asserts `off` when `watched_value = 10`
3. Sets `watched_value = 75`, asserts `on`
4. Sets `watched_value = 25`, asserts `off` again

**Verified to FAIL on `origin/main`** (bug exists) and **PASS on this branch** (fix works).

## Results

- 86 tests pass (+1 new), 0 regressions on this PR
- 20 pre-existing failures unchanged (entity_id naming addressed by PR #13; snooze-timer cleanup is a separate bug)

## Notes

- Imports added: `async_track_template_result`, `TrackTemplate` from `homeassistant.helpers.event`
- The `info.async_refresh()` call kicks off the initial render so HA can discover the referenced entities to subscribe to (otherwise the listener wouldn't fire until a manual refresh)
- This is independent of PR #13 (entity naming) and can land on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)