### PR TITLE
fix: hub summary sensor state reports active-alert count

### DIFF
--- a/custom_components/emergency_alerts/sensor.py
+++ b/custom_components/emergency_alerts/sensor.py
@@ -92,13 +92,24 @@ class EmergencyGlobalSummarySensor(SensorEntity):
 
 
 class EmergencyHubSensor(SensorEntity):
-    """Sensor representing the Emergency Alerts hub device."""
+    """Sensor representing the Emergency Alerts hub device.
+
+    The state reports the count of currently-firing alerts in this hub —
+    not the total configured. Use this for dashboard visibility gating
+    ("show the hub section when state > 0"). The total-configured count
+    is exposed via the ``configured_count`` attribute, and the firing IDs
+    via ``active_alerts``.
+    """
+
+    _attr_should_poll = False
 
     def __init__(self, hass, entry, group_name, hub_name):
         self.hass = hass
         self._entry = entry
         self._group_name = group_name
         self._hub_name = hub_name
+        self._active_alerts: list[str] = []
+        self._unsub = None
 
         self._attr_name = f"Emergency Alerts {group_name.title()} Summary"
         self._attr_unique_id = f"emergency_alerts_hub_{hub_name}"
@@ -119,19 +130,53 @@ class EmergencyHubSensor(SensorEntity):
             "sw_version": "1.0",
         }
 
+    async def async_added_to_hass(self):
+        """Subscribe to alert state-change broadcasts."""
+        from .binary_sensor import SUMMARY_UPDATE_SIGNAL
+
+        @callback
+        def update_summary():
+            self._refresh_active_alerts()
+            self.async_write_ha_state()
+
+        self._unsub = async_dispatcher_connect(
+            self.hass, SUMMARY_UPDATE_SIGNAL, update_summary
+        )
+        self._refresh_active_alerts()
+
+    async def async_will_remove_from_hass(self):
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    def _refresh_active_alerts(self):
+        """Recompute the list of currently-firing alert entity_ids in this hub."""
+        entities = self.hass.data.get(DOMAIN, {}).get("entities", [])
+        self._active_alerts = [
+            e.entity_id
+            for e in entities
+            if getattr(e, "_hub_name", None) == self._hub_name and e.is_on
+        ]
+
     @property
     def native_value(self):
-        """Return the number of alerts in this hub."""
-        alerts_data = self._entry.data.get("alerts", {})
-        return len(alerts_data)
+        """Number of currently-firing alerts in this hub (0 when nothing active)."""
+        return len(self._active_alerts)
 
     @property
     def extra_state_attributes(self):
-        """Return additional attributes."""
+        """Return additional attributes.
+
+        ``alert_count`` (deprecated alias) and ``configured_count`` both report
+        the total number of alerts configured in this hub. ``active_alerts``
+        is the list of currently-firing alert entity_ids.
+        """
         alerts_data = self._entry.data.get("alerts", {})
         return {
             "group": self._group_name,
             "hub_name": self._hub_name,
-            "alert_count": len(alerts_data),
+            "configured_count": len(alerts_data),
+            "alert_count": len(alerts_data),  # Backward-compat alias
             "alerts": list(alerts_data.keys()),
+            "active_alerts": list(self._active_alerts),
         }

--- a/custom_components/emergency_alerts/tests/integration/test_sensor_updates.py
+++ b/custom_components/emergency_alerts/tests/integration/test_sensor_updates.py
@@ -38,30 +38,61 @@ async def test_global_summary_sensor_updates(hass: HomeAssistant, init_group_hub
 
 
 @pytest.mark.integration
-async def test_hub_summary_sensor_counts_alerts(hass: HomeAssistant, init_group_hub):
-    """Test that hub summary sensor counts alerts correctly."""
+async def test_hub_summary_state_is_active_count_attrs_carry_configured(
+    hass: HomeAssistant, init_group_hub
+):
+    """Hub summary state = firing-alert count (for visibility gating); configured count is in attrs."""
     await hass.async_block_till_done()
-    
+
     hub_summary_id = "sensor.emergency_alerts_security_summary"
-    
-    # Should have 1 alert configured
     hub_state = hass.states.get(hub_summary_id)
     assert hub_state is not None
-    assert_sensor_value(hass, hub_summary_id, 1)
-    
-    # Check attributes
+
+    # Nothing is firing yet → state is 0 (so `numeric_state > 0` gates work)
+    assert_sensor_value(hass, hub_summary_id, 0)
+
+    # Configured-count + alert list still available via attributes
     assert hub_state.attributes.get("group") == "security"
-    assert hub_state.attributes.get("alert_count") == 1
-    alerts = hub_state.attributes.get("alerts", [])
-    assert "test_alert" in alerts
+    assert hub_state.attributes.get("configured_count") == 1
+    assert hub_state.attributes.get("alert_count") == 1  # legacy alias
+    assert "test_alert" in hub_state.attributes.get("alerts", [])
+    assert hub_state.attributes.get("active_alerts") == []
 
 
 @pytest.mark.integration
-async def test_summary_sensor_multiple_alerts(hass: HomeAssistant, init_group_hub):
-    """Test summary sensor with multiple alerts."""
+async def test_hub_summary_state_flips_with_firing_alert(
+    hass: HomeAssistant, init_group_hub
+):
+    """Hub summary state moves 0 → 1 → 0 as the underlying alert fires/clears."""
     await hass.async_block_till_done()
-    
-    # Add another alert to the hub
+    hub_summary_id = "sensor.emergency_alerts_security_summary"
+    monitored = "binary_sensor.test_sensor"
+
+    # Baseline: nothing firing
+    assert_sensor_value(hass, hub_summary_id, 0)
+
+    # Trigger the alert
+    set_entity_state(hass, monitored, "on")
+    await hass.async_block_till_done()
+    assert_sensor_value(hass, hub_summary_id, 1)
+    hub_state = hass.states.get(hub_summary_id)
+    assert hub_state.attributes.get("active_alerts") == [
+        "binary_sensor.emergency_test_alert"
+    ]
+
+    # Clear the alert
+    set_entity_state(hass, monitored, "off")
+    await hass.async_block_till_done()
+    assert_sensor_value(hass, hub_summary_id, 0)
+
+
+@pytest.mark.integration
+async def test_summary_sensor_configured_count_updates_on_add(
+    hass: HomeAssistant, init_group_hub
+):
+    """Adding an alert bumps configured_count attribute while state stays 0 (nothing firing)."""
+    await hass.async_block_till_done()
+
     entry = init_group_hub
     alerts = dict(entry.data.get("alerts", {}))
     alerts["test_alert_2"] = {
@@ -71,13 +102,14 @@ async def test_summary_sensor_multiple_alerts(hass: HomeAssistant, init_group_hu
         "trigger_state": "on",
         "severity": "critical",
     }
-    
+
     new_data = dict(entry.data)
     new_data["alerts"] = alerts
     hass.config_entries.async_update_entry(entry, data=new_data)
     await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
-    
-    # Hub summary should show 2 alerts
+
     hub_summary_id = "sensor.emergency_alerts_security_summary"
-    assert_sensor_value(hass, hub_summary_id, 2)
+    assert_sensor_value(hass, hub_summary_id, 0)
+    hub_state = hass.states.get(hub_summary_id)
+    assert hub_state.attributes.get("configured_count") == 2

--- a/custom_components/emergency_alerts/tests/test_sensor.py
+++ b/custom_components/emergency_alerts/tests/test_sensor.py
@@ -42,9 +42,9 @@ def test_global_summary_sensor_counts_active_alerts(hass: HomeAssistant, mock_en
     assert sensor.extra_state_attributes["alert_count"] == 3
 
 
-def test_hub_sensor_counts_alerts_in_entry(hass: HomeAssistant):
-    """Test that hub sensor counts alerts in its config entry."""
-    # Create a mock config entry
+def test_hub_sensor_native_value_is_active_count(hass: HomeAssistant):
+    """Hub sensor state = active count (defaults 0); configured count lives in attrs."""
+    # Create a mock config entry with 3 alerts configured, none firing yet
     mock_entry = MagicMock()
     mock_entry.data = {
         "hub_type": "group",
@@ -59,10 +59,15 @@ def test_hub_sensor_counts_alerts_in_entry(hass: HomeAssistant):
 
     sensor = EmergencyHubSensor(hass, mock_entry, "security", "Security Alerts")
 
-    assert sensor.native_value == 3
-    assert sensor.extra_state_attributes["group"] == "security"
-    assert sensor.extra_state_attributes["alert_count"] == 3
-    assert set(sensor.extra_state_attributes["alerts"]) == {"alert1", "alert2", "alert3"}
+    # State = count of FIRING alerts (initialized empty list before subscribe)
+    assert sensor.native_value == 0
+    # Configured count is in attributes (with legacy `alert_count` alias)
+    attrs = sensor.extra_state_attributes
+    assert attrs["group"] == "security"
+    assert attrs["configured_count"] == 3
+    assert attrs["alert_count"] == 3  # legacy alias
+    assert set(attrs["alerts"]) == {"alert1", "alert2", "alert3"}
+    assert attrs["active_alerts"] == []
 
 
 def test_hub_sensor_empty_hub(hass: HomeAssistant):


### PR DESCRIPTION
## The bug

`EmergencyHubSensor.native_value` returned the count of *configured* alerts in the hub (`len(self._entry.data.get(\"alerts\", {}))`). That value never changes during normal operation, so dashboard `numeric_state > 0` gates always passed. Per-hub sections in the lovelace card dashboard never actually hid when nothing was firing.

## The fix

Mirror `EmergencyGlobalSummarySensor` (which already gets this right): subscribe to `SUMMARY_UPDATE_SIGNAL`, recompute the active list from `hass.data[DOMAIN][\"entities\"]` filtered by hub. State is now the count of currently-firing alerts in this hub.

## Backwards compatibility

- `extra_state_attributes` retains **`alert_count`** as an alias for configured count (existing automations that read it keep working)
- Adds **`configured_count`** attribute (explicit name)
- Adds **`active_alerts`** attribute (list of firing `binary_sensor.emergency_*` IDs in this hub)
- `_attr_should_poll = False` added to match the global sensor

## Test updates

| Test | Before | After |
|---|---|---|
| `test_sensor.py::test_hub_sensor_counts_alerts_in_entry` | state=3 (configured) | renamed to `test_hub_sensor_native_value_is_active_count`; state=0, attrs.configured_count=3 |
| `test_sensor_updates.py::test_hub_summary_sensor_counts_alerts` | state=1 (configured) | renamed to `..._is_active_count_attrs_carry_configured`; state=0, attrs.configured_count=1 |
| `test_sensor_updates.py::test_summary_sensor_multiple_alerts` | state=2 after add | renamed to `..._configured_count_updates_on_add`; state=0, attrs.configured_count=2 |
| **NEW**: `test_hub_summary_state_flips_with_firing_alert` | n/a | regression test — set monitored entity on, assert state 0 → 1 → 0 |

## Test results

- **87 passed** (was 85)
- 3 pre-existing teardown errors unchanged (`test_snooze_select_updates_binary_sensor`, `test_select_mutual_exclusivity`, `test_concurrent_updates` — `_snooze_timer` not cancelled on entity removal, separate bug)

## Migration note for users

If your dashboard or automation gated on the hub summary's `state` to mean "is anything configured", switch to `attributes.configured_count`. If you wanted "is anything firing" (the more common intent), no change needed — the new behavior matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)