### PR TITLE
fix: EntitySelector fields reject empty submissions (Bug 6)

### DIFF
--- a/custom_components/emergency_alerts/config_flow.py
+++ b/custom_components/emergency_alerts/config_flow.py
@@ -24,6 +24,21 @@ def _slugify_alert_id(name: str) -> str:
     slug = re.sub(r"[^a-z0-9_]+", "_", name.lower()).strip("_")
     return re.sub(r"_+", "_", slug)
 
+
+def _optional(key: str, value: Any = None) -> vol.Optional:
+    """Build a vol.Optional that pre-fills via `suggested_value`, not `default`.
+
+    `EntitySelector` rejects empty strings ("Entity not found"), so passing
+    `default=""` to an Optional EntitySelector breaks form submission whenever
+    the field is left blank. The HA-idiomatic alternative is to pre-fill the
+    visible value via `description={"suggested_value": ...}` and leave the
+    schema default unset. When `value` is falsy we omit even the suggestion so
+    the field renders truly empty.
+    """
+    if value:
+        return vol.Optional(key, description={"suggested_value": value})
+    return vol.Optional(key)
+
 from .const import (
     DOMAIN,
     CONF_HUB_TYPE,
@@ -201,7 +216,7 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("entity_id", default=defaults.get("entity_id", "")): selector.EntitySelector(),
+            _optional("entity_id", defaults.get("entity_id")): selector.EntitySelector(),
             vol.Optional(
                 "trigger_state", default=defaults.get("trigger_state", "on")
             ): str,
@@ -214,7 +229,7 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
             vol.Optional(
                 "for_seconds", default=defaults.get("for_seconds", 0)
             ): vol.All(vol.Coerce(int), vol.Range(min=0, max=86400)),
-            vol.Optional("on_triggered_script", default=defaults.get("on_triggered_script", "")): selector.EntitySelector(
+            _optional("on_triggered_script", defaults.get("on_triggered_script")): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="script")
             ),
         })

--- a/custom_components/emergency_alerts/tests/test_config_flow.py
+++ b/custom_components/emergency_alerts/tests/test_config_flow.py
@@ -1,9 +1,14 @@
 """Test the Emergency Alerts config flow."""
 
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
-from custom_components.emergency_alerts.config_flow import EmergencyAlertsConfigFlow
+from custom_components.emergency_alerts.config_flow import (
+    EmergencyAlertsConfigFlow,
+    EmergencyOptionsFlow,
+    _optional,
+)
 from custom_components.emergency_alerts.const import DOMAIN
 
 
@@ -114,3 +119,77 @@ async def test_config_flow_defaults(hass: HomeAssistant):
     for field, validator in schema.items():
         if hasattr(field, "schema") and field.schema == "trigger_type":
             break
+
+
+# ---------------------------------------------------------------------------
+# Bug 6 regression — EntitySelector default="" rejects empty submissions.
+# Verifies the `_optional()` helper builds a schema marker that omits any
+# default value when there's nothing to suggest, so the field's selector is
+# never asked to validate an empty string. With the old `default=""` pattern,
+# submitting the form without picking an entity raised "Entity not found".
+# ---------------------------------------------------------------------------
+
+
+def test_optional_helper_omits_default_when_value_falsy():
+    """`_optional(k)` and `_optional(k, "")` produce a bare vol.Optional."""
+    marker_none = _optional("entity_id")
+    marker_empty = _optional("entity_id", "")
+    marker_falsy_zero = _optional("entity_id", 0)
+
+    assert isinstance(marker_none, vol.Optional)
+    assert marker_none.default is vol.UNDEFINED
+    # voluptuous stores description as `description` attribute
+    assert getattr(marker_none, "description", None) is None
+
+    assert getattr(marker_empty, "description", None) is None
+    assert getattr(marker_falsy_zero, "description", None) is None
+
+
+def test_optional_helper_uses_suggested_value_when_truthy():
+    """`_optional(k, "light.foo")` sets suggested_value, not default."""
+    marker = _optional("entity_id", "light.foo")
+    assert isinstance(marker, vol.Optional)
+    assert marker.default is vol.UNDEFINED
+    assert marker.description == {"suggested_value": "light.foo"}
+
+
+def test_alert_schema_accepts_empty_submission_with_no_entity_id():
+    """Empty form submission must not fail EntitySelector validation.
+
+    Prior to Bug 6 fix, `vol.Optional("entity_id", default="")` injected an
+    empty string into the validated data when the user left the field blank,
+    and EntitySelector rejected it as "Entity not found". The fix uses
+    `description={"suggested_value": ...}` for pre-fill, with no schema
+    default, so empty submissions pass through cleanly.
+    """
+    flow = EmergencyOptionsFlow()
+    schema = flow._build_alert_schema()
+
+    # Minimum valid submission for a template trigger: no entity_id, just
+    # severity + trigger_type + template + name.
+    result = schema({
+        "name": "Test Alert",
+        "severity": "warning",
+        "trigger_type": "template",
+        "template": "{{ True }}",
+    })
+
+    # entity_id must NOT have been injected as ""
+    assert "entity_id" not in result
+    # on_triggered_script must NOT have been injected as ""
+    assert "on_triggered_script" not in result
+
+
+def test_alert_schema_preserves_existing_entity_id_via_suggested_value():
+    """Editing an alert: existing entity_id should re-appear as suggestion."""
+    flow = EmergencyOptionsFlow()
+    schema = flow._build_alert_schema(defaults={"entity_id": "binary_sensor.front_door"})
+
+    # Find the entity_id marker and check the suggested_value attached
+    for marker in schema.schema:
+        if getattr(marker, "schema", None) == "entity_id":
+            assert marker.description == {"suggested_value": "binary_sensor.front_door"}
+            assert marker.default is vol.UNDEFINED
+            break
+    else:
+        raise AssertionError("entity_id field not found in schema")


### PR DESCRIPTION
## Summary

- Fixes Bug 6: add/edit alert form refused to submit whenever an `EntitySelector` field (`entity_id`, `on_triggered_script`) was left blank, raising "Entity not found"
- Introduces a small `_optional(key, value)` helper in `config_flow.py` that uses `description={"suggested_value": ...}` for pre-fill (visible to user, no schema validation) instead of `default=""` (which voluptuous would inject as an empty string and EntitySelector then rejects)
- Adds 4 regression tests covering the helper semantics and schema behavior for both empty and pre-filled defaults

## Background

The v4.1.0 changelog already called this out:

> **Known incompatibilities**: `EntitySelector` fields must not have default values. A `default=""` triggers "Entity not found" validation. Leave EntitySelectors unset by default.

This PR removes that limitation. The pattern is HA-idiomatic — `description={"suggested_value": ...}` is what HA's own integrations (e.g. `template`, `group`, `min_max`) use for pre-filling EntitySelectors in edit flows.

The `template` field (`TemplateSelector`) keeps its `default=""` because TemplateSelector accepts arbitrary strings; the bug is specific to selectors that validate against the entity registry.

## Test plan

- [x] `_optional()` helper unit tests pass (4 cases: bare optional, empty-string falsy, zero falsy, truthy entity_id)
- [x] `_build_alert_schema()` accepts a minimum-fields submission (no entity_id, no on_triggered_script) without validation error
- [x] `_build_alert_schema(defaults={"entity_id": "binary_sensor.foo"})` attaches `suggested_value` (not `default`) so editing preserves the existing value without forcing it
- [x] Full Docker test suite still passes (96 tests, 3 pre-existing unrelated state-sync flakes)
- [ ] Live test post-merge: edit one of the existing 21 alerts in HA, leave entity_id blank, save → expect no "Entity not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)