### PR TITLE
fix: edit-alert form no longer misfires as 'already_configured'

### DIFF
--- a/custom_components/emergency_alerts/config_flow.py
+++ b/custom_components/emergency_alerts/config_flow.py
@@ -160,17 +160,33 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
         )
 
     async def async_step_add_alert(self, user_input=None):
-        """Add alert - SINGLE PAGE with ALL fields."""
+        """Add or edit alert - SINGLE PAGE with ALL fields.
+
+        Doubles as the form-submission handler for `edit_alert_form` because
+        that step reuses `step_id="add_alert"` for the form rendering. When
+        `self._editing_alert_id` is set we treat the submission as an edit:
+        the existing alert_id is allowed (it's the one being edited) and we
+        drop the old key if the name change produces a different slug.
+        """
         errors = {}
+        editing_id = getattr(self, "_editing_alert_id", None)
 
         if user_input is not None:
             try:
                 alert_id = _slugify_alert_id(user_input["name"])
                 alerts = dict(self.config_entry.data.get(CONF_ALERTS, {}))
 
-                if alert_id in alerts:
+                # Duplicate-name guard: only applies to adds, or to edits where
+                # the user renamed the alert into a slug that collides with a
+                # different existing alert.
+                if alert_id in alerts and alert_id != editing_id:
                     errors["name"] = "already_configured"
                 else:
+                    # When editing with a renamed alert (slug changed), remove
+                    # the old key so we don't leave two copies behind.
+                    if editing_id and editing_id != alert_id:
+                        alerts.pop(editing_id, None)
+
                     alerts[alert_id] = self._build_alert_data(user_input)
                     new_data = dict(self.config_entry.data)
                     new_data[CONF_ALERTS] = alerts
@@ -179,18 +195,23 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
                         self.config_entry, data=new_data
                     )
 
-                    # Reload entry to create new entities instantly
+                    # Clear edit state so a subsequent add isn't treated as edit
+                    self._editing_alert_id = None
+
+                    # Reload entry to create/update entities instantly
                     await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
                     return self.async_create_entry(title="", data={})
 
             except Exception as err:
-                _LOGGER.error("Error creating alert: %s", err)
+                _LOGGER.error("Error %s alert: %s", "editing" if editing_id else "creating", err)
                 errors["base"] = "invalid_input"
 
         return self.async_show_form(
             step_id="add_alert",
-            data_schema=self._build_alert_schema(),
+            data_schema=self._build_alert_schema(
+                defaults=user_input if editing_id else None
+            ),
             errors=errors,
         )
 
@@ -315,12 +336,15 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
         )
 
     async def async_step_edit_alert_form(self, user_input=None):
-        """Show edit form with current values."""
-        alerts = dict(self.config_entry.data.get(CONF_ALERTS, {}))
-        alert_id = self._editing_alert_id
-        current_alert = alerts.get(alert_id, {})
+        """Render the edit form with current values pre-filled.
 
-        # Use current values as defaults
+        Form submission routes to `async_step_add_alert` because we reuse
+        `step_id="add_alert"` for translation/UX consistency. `add_alert`
+        detects edit mode via `self._editing_alert_id` set in
+        `async_step_edit_alert`.
+        """
+        alerts = dict(self.config_entry.data.get(CONF_ALERTS, {}))
+        current_alert = alerts.get(self._editing_alert_id, {})
         defaults = dict(current_alert)
 
         # Migrate old script array format to string
@@ -330,29 +354,8 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
             except (KeyError, IndexError, TypeError):
                 defaults["on_triggered_script"] = ""
 
-        if user_input is not None:
-            try:
-                # Update alert data
-                alerts[alert_id] = self._build_alert_data(user_input)
-                new_data = dict(self.config_entry.data)
-                new_data[CONF_ALERTS] = alerts
-
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry, data=new_data
-                )
-
-                # Reload to update entities
-                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-
-                return self.async_create_entry(title="", data={})
-
-            except Exception as err:
-                _LOGGER.error("Error updating alert: %s", err)
-                return self.async_abort(reason="update_failed")
-
-        # Show form pre-filled with current values (reuse add_alert step for same UX)
         return self.async_show_form(
-            step_id="add_alert",  # Reuse add_alert translations
+            step_id="add_alert",
             data_schema=self._build_alert_schema(defaults=defaults),
         )
 

--- a/custom_components/emergency_alerts/tests/test_config_flow.py
+++ b/custom_components/emergency_alerts/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Emergency Alerts config flow."""
 
+import pytest
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -162,8 +163,8 @@ def test_alert_schema_accepts_empty_submission_with_no_entity_id():
     `description={"suggested_value": ...}` for pre-fill, with no schema
     default, so empty submissions pass through cleanly.
     """
-    flow = EmergencyOptionsFlow()
-    schema = flow._build_alert_schema()
+    # _build_alert_schema doesn't touch self.config_entry — pure schema build
+    schema = EmergencyOptionsFlow._build_alert_schema(None)
 
     # Minimum valid submission for a template trigger: no entity_id, just
     # severity + trigger_type + template + name.
@@ -182,8 +183,9 @@ def test_alert_schema_accepts_empty_submission_with_no_entity_id():
 
 def test_alert_schema_preserves_existing_entity_id_via_suggested_value():
     """Editing an alert: existing entity_id should re-appear as suggestion."""
-    flow = EmergencyOptionsFlow()
-    schema = flow._build_alert_schema(defaults={"entity_id": "binary_sensor.front_door"})
+    schema = EmergencyOptionsFlow._build_alert_schema(
+        None, defaults={"entity_id": "binary_sensor.front_door"}
+    )
 
     # Find the entity_id marker and check the suggested_value attached
     for marker in schema.schema:
@@ -204,24 +206,42 @@ def test_alert_schema_preserves_existing_entity_id_via_suggested_value():
 # ---------------------------------------------------------------------------
 
 
-class _StubConfigEntry:
-    def __init__(self, data):
-        self.data = data
-        self.entry_id = "stub_entry"
+@pytest.fixture
+def _options_flow_factory(hass):
+    """Build an EmergencyOptionsFlow bound to a MockConfigEntry.
+
+    OptionsFlow.config_entry is a read-only property derived from
+    self.handler + hass.config_entries.options registry, so we register a
+    MockConfigEntry with hass and point self.handler at its entry_id.
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.emergency_alerts.const import DOMAIN
+
+    def factory(data):
+        entry = MockConfigEntry(
+            domain=DOMAIN, version=2, data=data,
+            title=data.get("hub_name", "Test Hub"),
+        )
+        entry.add_to_hass(hass)
+        flow = EmergencyOptionsFlow()
+        flow.hass = hass
+        flow.handler = entry.entry_id
+        return flow
+
+    return factory
 
 
-def _make_options_flow_with_alerts(alerts: dict) -> EmergencyOptionsFlow:
-    """Build an EmergencyOptionsFlow bound to a stub entry holding alerts."""
-    flow = EmergencyOptionsFlow.__new__(EmergencyOptionsFlow)
-    flow.config_entry = _StubConfigEntry({"alerts": alerts})
-    return flow
-
-
-async def test_add_alert_blocks_duplicate_name_when_not_editing():
+async def test_add_alert_blocks_duplicate_name_when_not_editing(_options_flow_factory):
     """Without `_editing_alert_id`, slug-matched submission errors as expected."""
-    flow = _make_options_flow_with_alerts({
-        "external_door_open": {"name": "External Door Open", "severity": "warning",
-                               "trigger_type": "simple", "entity_id": "binary_sensor.front_door"}
+    flow = _options_flow_factory({
+        "alerts": {
+            "external_door_open": {
+                "name": "External Door Open", "severity": "warning",
+                "trigger_type": "simple",
+                "entity_id": "binary_sensor.front_door",
+                "trigger_state": "on",
+            }
+        }
     })
     flow._editing_alert_id = None
     result = await flow.async_step_add_alert({
@@ -235,7 +255,7 @@ async def test_add_alert_blocks_duplicate_name_when_not_editing():
     assert result["errors"] == {"name": "already_configured"}
 
 
-async def test_edit_alert_does_not_misfire_already_configured(hass):
+async def test_edit_alert_does_not_misfire_already_configured(_options_flow_factory):
     """Edit submission with the SAME name must NOT raise already_configured.
 
     Regression for v4.1.0/4.2.0 bug: edit_alert_form rendered with
@@ -243,23 +263,16 @@ async def test_edit_alert_does_not_misfire_already_configured(hass):
     then ran the duplicate-name guard and rejected the edit. add_alert now
     permits the slug match when `_editing_alert_id` is set.
     """
-    from custom_components.emergency_alerts.const import DOMAIN
-    entry = config_entries.ConfigEntry(
-        version=2, minor_version=0, domain=DOMAIN,
-        title="Security", data={"alerts": {
+    flow = _options_flow_factory({
+        "alerts": {
             "external_door_open": {
                 "name": "External Door Open", "severity": "warning",
                 "trigger_type": "template",
                 "template": "{{ is_state('binary_sensor.front_door','on') }}",
                 "on_triggered_script": "script.emergency_critical_push",
             }
-        }}, source="user", unique_id="stub", options={},
-        discovery_keys={}, subentries_data=None,
-    )
-    entry.add_to_hass(hass)
-    flow = EmergencyOptionsFlow()
-    flow.hass = hass
-    flow.config_entry = entry
+        }
+    })
     flow._editing_alert_id = "external_door_open"
 
     result = await flow.async_step_add_alert({
@@ -276,29 +289,22 @@ async def test_edit_alert_does_not_misfire_already_configured(hass):
     # Editing state cleared
     assert flow._editing_alert_id is None
     # on_triggered_script dropped from storage
-    saved = entry.data["alerts"]["external_door_open"]
+    saved = flow.config_entry.data["alerts"]["external_door_open"]
     assert "on_triggered_script" not in saved
     assert saved.get("for_seconds") == 60
 
 
-async def test_edit_alert_with_renamed_slug_drops_old_key(hass):
+async def test_edit_alert_with_renamed_slug_drops_old_key(_options_flow_factory):
     """Renaming an alert during edit removes the old slug and adds the new one."""
-    from custom_components.emergency_alerts.const import DOMAIN
-    entry = config_entries.ConfigEntry(
-        version=2, minor_version=0, domain=DOMAIN, title="Security",
-        data={"alerts": {
+    flow = _options_flow_factory({
+        "alerts": {
             "old_name": {
                 "name": "Old Name", "severity": "warning",
                 "trigger_type": "simple", "entity_id": "binary_sensor.x",
                 "trigger_state": "on",
             }
-        }}, source="user", unique_id="stub2", options={},
-        discovery_keys={}, subentries_data=None,
-    )
-    entry.add_to_hass(hass)
-    flow = EmergencyOptionsFlow()
-    flow.hass = hass
-    flow.config_entry = entry
+        }
+    })
     flow._editing_alert_id = "old_name"
 
     result = await flow.async_step_add_alert({
@@ -310,6 +316,6 @@ async def test_edit_alert_with_renamed_slug_drops_old_key(hass):
     })
 
     assert result["type"] == "create_entry"
-    alerts = entry.data["alerts"]
+    alerts = flow.config_entry.data["alerts"]
     assert "old_name" not in alerts
     assert "new_name" in alerts

--- a/custom_components/emergency_alerts/tests/test_config_flow.py
+++ b/custom_components/emergency_alerts/tests/test_config_flow.py
@@ -193,3 +193,123 @@ def test_alert_schema_preserves_existing_entity_id_via_suggested_value():
             break
     else:
         raise AssertionError("entity_id field not found in schema")
+
+
+# ---------------------------------------------------------------------------
+# Edit-alert flow regression — submitting an edit_alert_form rendered with
+# step_id="add_alert" used to misfire as "already_configured" because the
+# duplicate-name guard didn't know it was an edit. async_step_add_alert now
+# reads `self._editing_alert_id` (set by edit_alert) and allows the slug
+# match when it matches the editing target.
+# ---------------------------------------------------------------------------
+
+
+class _StubConfigEntry:
+    def __init__(self, data):
+        self.data = data
+        self.entry_id = "stub_entry"
+
+
+def _make_options_flow_with_alerts(alerts: dict) -> EmergencyOptionsFlow:
+    """Build an EmergencyOptionsFlow bound to a stub entry holding alerts."""
+    flow = EmergencyOptionsFlow.__new__(EmergencyOptionsFlow)
+    flow.config_entry = _StubConfigEntry({"alerts": alerts})
+    return flow
+
+
+async def test_add_alert_blocks_duplicate_name_when_not_editing():
+    """Without `_editing_alert_id`, slug-matched submission errors as expected."""
+    flow = _make_options_flow_with_alerts({
+        "external_door_open": {"name": "External Door Open", "severity": "warning",
+                               "trigger_type": "simple", "entity_id": "binary_sensor.front_door"}
+    })
+    flow._editing_alert_id = None
+    result = await flow.async_step_add_alert({
+        "name": "External Door Open",  # collides
+        "severity": "warning",
+        "trigger_type": "simple",
+        "entity_id": "binary_sensor.front_door",
+        "trigger_state": "on",
+    })
+    assert result["type"] == "form"
+    assert result["errors"] == {"name": "already_configured"}
+
+
+async def test_edit_alert_does_not_misfire_already_configured(hass):
+    """Edit submission with the SAME name must NOT raise already_configured.
+
+    Regression for v4.1.0/4.2.0 bug: edit_alert_form rendered with
+    step_id="add_alert" caused HA to route POSTs back to add_alert, which
+    then ran the duplicate-name guard and rejected the edit. add_alert now
+    permits the slug match when `_editing_alert_id` is set.
+    """
+    from custom_components.emergency_alerts.const import DOMAIN
+    entry = config_entries.ConfigEntry(
+        version=2, minor_version=0, domain=DOMAIN,
+        title="Security", data={"alerts": {
+            "external_door_open": {
+                "name": "External Door Open", "severity": "warning",
+                "trigger_type": "template",
+                "template": "{{ is_state('binary_sensor.front_door','on') }}",
+                "on_triggered_script": "script.emergency_critical_push",
+            }
+        }}, source="user", unique_id="stub", options={},
+        discovery_keys={}, subentries_data=None,
+    )
+    entry.add_to_hass(hass)
+    flow = EmergencyOptionsFlow()
+    flow.hass = hass
+    flow.config_entry = entry
+    flow._editing_alert_id = "external_door_open"
+
+    result = await flow.async_step_add_alert({
+        "name": "External Door Open",        # same name — same slug
+        "severity": "warning",
+        "trigger_type": "template",
+        "template": "{{ is_state('binary_sensor.front_door','on') }}",
+        "for_seconds": 60,
+        # deliberately omit on_triggered_script — this is the migration case
+    })
+
+    # Edit succeeds and closes the flow
+    assert result["type"] == "create_entry", f"Expected create_entry, got {result}"
+    # Editing state cleared
+    assert flow._editing_alert_id is None
+    # on_triggered_script dropped from storage
+    saved = entry.data["alerts"]["external_door_open"]
+    assert "on_triggered_script" not in saved
+    assert saved.get("for_seconds") == 60
+
+
+async def test_edit_alert_with_renamed_slug_drops_old_key(hass):
+    """Renaming an alert during edit removes the old slug and adds the new one."""
+    from custom_components.emergency_alerts.const import DOMAIN
+    entry = config_entries.ConfigEntry(
+        version=2, minor_version=0, domain=DOMAIN, title="Security",
+        data={"alerts": {
+            "old_name": {
+                "name": "Old Name", "severity": "warning",
+                "trigger_type": "simple", "entity_id": "binary_sensor.x",
+                "trigger_state": "on",
+            }
+        }}, source="user", unique_id="stub2", options={},
+        discovery_keys={}, subentries_data=None,
+    )
+    entry.add_to_hass(hass)
+    flow = EmergencyOptionsFlow()
+    flow.hass = hass
+    flow.config_entry = entry
+    flow._editing_alert_id = "old_name"
+
+    result = await flow.async_step_add_alert({
+        "name": "New Name",
+        "severity": "warning",
+        "trigger_type": "simple",
+        "entity_id": "binary_sensor.x",
+        "trigger_state": "on",
+    })
+
+    assert result["type"] == "create_entry"
+    alerts = entry.data["alerts"]
+    assert "old_name" not in alerts
+    assert "new_name" in alerts


### PR DESCRIPTION
## Summary

- Fixes a latent bug in the edit-alert flow: submitting the form for an existing alert raised \`{name: already_configured}\` even when the name was unchanged
- The duplicate-name guard in \`async_step_add_alert\` now respects \`self._editing_alert_id\` and allows the slug match when it's the alert being edited
- Removes the unreachable submission branch from \`async_step_edit_alert_form\` (POSTs route to \`add_alert\` because the form's \`step_id=\"add_alert\"\`)
- 3 regression tests in \`test_config_flow.py\` covering: add-mode still blocks duplicates, edit-mode same-name passes, edit-mode rename drops old slug

## Why now

Discovered while trying to programmatically migrate the 14 non-Critical alerts on my live HA off \`on_triggered_script\` via the options flow. Every \`edit_alert\` submission errored out with \`{name: already_configured}\`, regardless of the field I was trying to update. Both the add and edit paths share the same form rendering (\`step_id=\"add_alert\"\`); the duplicate-name guard didn't know about edit context. Now it does.

This unblocks any tooling that wants to update existing alerts via the options flow API.

## Test plan

- [x] \`test_add_alert_blocks_duplicate_name_when_not_editing\` — without \`_editing_alert_id\`, slug-matched submission still errors
- [x] \`test_edit_alert_does_not_misfire_already_configured\` — edit submission with same name succeeds and persists field deletions
- [x] \`test_edit_alert_with_renamed_slug_drops_old_key\` — renaming an alert removes the old slug, adds the new one
- [x] All CI checks (Hassfest, HACS Validation, Backend Tests, Lint, Architect-Gate)
- [ ] Post-merge: programmatic migration of the 14 non-Critical alerts via the options flow should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)