### PR TITLE
chore: drop dangling dev symlink shipped in releases

### DIFF
--- a/custom_components/emergency_alerts/emergency_alerts
+++ b/custom_components/emergency_alerts/emergency_alerts
@@ -1,1 +1,0 @@
-/workspaces/emergency_alerts/custom_components/emergency_alerts


### PR DESCRIPTION
## Summary

\`custom_components/emergency_alerts/emergency_alerts\` was a symlink to \`/workspaces/emergency_alerts/...\` — leftover from devcontainer/Codespace setup. The absolute path doesn't exist on user machines, so it shipped in every GitHub release tarball as a broken symlink.

Result: HACS's post-extract backup step on every update failed with \`FileNotFoundError: ...emergency_alerts/emergency_alerts\`. (Non-fatal — backup is best-effort — but noisy in logs, and on certain HACS code paths it cascaded into a 500 on \`update.install\`.)

## Test plan

- [x] No code changes; just \`git rm\` the symlink
- [ ] After merge, the next release tarball will be symlink-free → clean HACS install path

🤖 Generated with [Claude Code](https://claude.com/claude-code)