### PR TITLE
release: v4.2.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# `export-ignore` keeps these out of `git archive` (which is what GitHub
+# builds for release tarballs, and what HACS downloads). Anything still
+# in the working tree is fine for local dev; this just stops it from
+# being shipped to every user who installs via HACS.
+#
+# Inside the integration directory — these end up under
+# /config/custom_components/emergency_alerts/ on user installs if not
+# excluded, and serve no runtime purpose.
+custom_components/emergency_alerts/tests/                                 export-ignore
+custom_components/emergency_alerts/test_requirements.txt                  export-ignore
+custom_components/emergency_alerts/htmlcov/                               export-ignore
+custom_components/emergency_alerts/__pycache__/                           export-ignore
+
+# Repo root — dev-only files that shouldn't even appear in source archives
+# downloaded by HACS (HACS only extracts custom_components/, but smaller
+# tarballs are nicer and these aren't useful to users).
+.claude/                                                                  export-ignore
+.cursor/                                                                  export-ignore
+.devcontainer/                                                            export-ignore
+.devcontainer.json                                                        export-ignore
+.github/                                                                  export-ignore
+.pytest_cache/                                                            export-ignore
+.screenshots/                                                             export-ignore
+CLAUDE.md                                                                 export-ignore
+CONTRIBUTING.md                                                           export-ignore
+Dockerfile.lint                                                           export-ignore
+Dockerfile.test                                                           export-ignore
+dev_tools/                                                                export-ignore
+docker-compose.yml                                                        export-ignore
+docs/                                                                     export-ignore
+e2e-tests/                                                                export-ignore
+lovelace-emergency-alerts-card/                                           export-ignore
+pyproject.toml                                                            export-ignore
+pytest.ini                                                                export-ignore
+scripts/                                                                  export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 No unreleased changes.
 
+## [4.2.2] - 2026-05-26
+
+Cleanup release: gets PRs #24 and #25 into a tagged version, corrects the
+`hacs.json` HA-version claim, stops shipping dev artifacts in release
+tarballs, and rounds out the README with an honest comparison to HA's
+built-in `alert:` / `notify:`. No functional changes to alert behavior —
+upgrade is risk-free.
+
+### Fixed
+
+- **`hacs.json` claimed HA 2023.1.0 minimum, which was a lie.** The
+  integration uses `OptionsFlow.config_entry` as a sealed property — a
+  feature that landed in HA 2026.2. On anything older, every options-flow
+  step raises `AttributeError: 'EmergencyOptionsFlow' object has no
+  attribute 'config_entry'`. Bumped `hacs.json` and `test_requirements.txt`
+  to `homeassistant>=2026.2.0` so HACS users see the correct compatibility
+  warning and the test image matches the true floor.
+- **Test image was running HA 2024.3.3** because `test_requirements.txt`
+  said `>=2024.1.0`, so three integration tests (`test_concurrent_updates`,
+  `test_snooze_select_updates_binary_sensor`, `test_select_mutual_exclusivity`)
+  appeared "flaky" — they were actually hitting the `config_entry`
+  attribute-error on the older HA. Pinning the test floor to 2026.2
+  resolves them; all 99 tests now pass on the matched-floor image.
+
+### Changed
+
+- **Stop shipping dev artifacts in release tarballs.** Added
+  `.gitattributes` with `export-ignore` for `tests/`, `test_requirements.txt`,
+  `htmlcov/`, `dev_tools/`, `e2e-tests/`, `.devcontainer/`, `Dockerfile.*`,
+  `docker-compose.yml`, `scripts/`, `docs/`, the `lovelace-emergency-alerts-card`
+  vendored copy, and other dev-only paths. The next release tarball drops
+  from ~bloat to ~180KB and no longer creates spurious `tests/` and
+  `test_requirements.txt` files under `custom_components/emergency_alerts/`
+  on user installs. ([#24](https://github.com/issmirnov/emergency_alerts/pull/24) covered the symlink; this finishes the cleanup.)
+- **Bumped `Dockerfile.test` base to `python:3.13-slim`** to match HA
+  2026's Python-3.13 requirement (CI was already on 3.13; the Dockerfile
+  drifted).
+- **Bumped `pyproject.toml` mypy target to `3.13`** (was `3.9`).
+
+### Documentation
+
+- **README: added "How it compares to HA's built-in `alert:` and `notify:`"
+  section** — a side-by-side table covering config style, state model,
+  trigger types, ack/snooze/escalate semantics, severity rollups, and
+  when to pick each. Helps anyone evaluating against the in-tree options.
+
+### Workflow
+
+- **Architect-Gate now actually reviews diffs.** The Claude review action
+  was running with no tools and couldn't read the diff file or run git;
+  every SAR landed as "you haven't provided a PR diff". Added
+  `--allowed-tools Read,Grep,Glob,Bash(git*)` and appended a PR Changes
+  Summary block with explicit git commands. Mirrors the working config
+  in `chronicle` and `claude-k8s`. ([#25](https://github.com/issmirnov/emergency_alerts/pull/25))
+- **Dropped dangling dev-mode symlink** `custom_components/emergency_alerts/emergency_alerts`
+  that shipped in every release tarball as a broken symlink and made
+  HACS's post-extract backup step error out. ([#24](https://github.com/issmirnov/emergency_alerts/pull/24))
+
 ## [4.2.1] - 2026-05-26
 
 Single-bug patch release. Cuts a separate version because the fix unblocks

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,6 @@
 # Dockerfile for Emergency Alerts Integration Backend Testing
-FROM python:3.11-slim
+# Python 3.13 required: Home Assistant 2026.x dropped 3.11/3.12 support.
+FROM python:3.13-slim
 
 WORKDIR /app
 
@@ -26,7 +27,7 @@ COPY custom_components/emergency_alerts/test_requirements.txt ./test_requirement
 # Install Python dependencies
 RUN pip install --no-cache-dir -r test_requirements.txt pytz
 
-ENV PYTHONPATH="/app:/usr/local/lib/python3.11/site-packages"
+ENV PYTHONPATH="/app:/usr/local/lib/python3.13/site-packages"
 
 # Create test runner script
 RUN echo '#!/bin/bash\nset -e\necho "🚦 Running Emergency Alerts Integration Backend Tests"\necho "Working directory: $(pwd)"\necho "Python version: $(python --version)"\necho "Timezone: $(cat /etc/timezone)"\necho ""\necho "Test files:"\nfind custom_components/emergency_alerts/tests -name "test_*.py" -type f | sort\necho ""\npytest custom_components/emergency_alerts/tests/ --cov=custom_components.emergency_alerts --cov-report=term-missing -v' > /app/run_tests.sh && chmod +x /app/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ Everything is exposed as plain HA entities you can chart, automate against, or w
 - **UI-first** — full visual config flow, zero YAML required to set up alerts.
 - **Zero external runtime dependencies** — pure HA integration.
 
+## How it compares to HA's built-in `alert:` and `notify:`
+
+HA already ships two things that look adjacent. Here's when to use what:
+
+| | **`notify:`** (core) | **`alert:`** (core) | **`emergency_alerts`** (this) |
+|---|---|---|---|
+| Configuration | YAML | YAML | UI config flow |
+| Fires a notification | ✅ | ✅ (loops until ack) | ✅ (via `on_triggered_script` or any action hook) |
+| Has a state | ❌ (fire-and-forget) | `idle` / `on` | full lifecycle: `inactive` / `active` / `acknowledged` / `snoozed` / `escalated` / `resolved` |
+| Trigger types | n/a (caller decides) | state of one entity (`on`/`off`) | simple state match, Jinja template, or logical AND/OR over up to 10 conditions |
+| Sustain duration (alert only after condition is true for N seconds) | ❌ | ❌ | ✅ `for_seconds` field |
+| Acknowledge to silence | ❌ | ✅ (one way: turn off the alert switch) | ✅ (acknowledge / snooze / resolve, exposed as a `select` entity) |
+| Auto-escalation on unacked | ❌ | ❌ | ✅ separate `escalated` state + `on_escalated` action hook |
+| Reminder cadence | ❌ | `repeat:` minutes list | per-alert `remind_after_seconds` |
+| Multiple severity levels | ❌ | ❌ | `info` / `warning` / `critical`, rolled up per hub |
+| Group / hub roll-up sensor | ❌ | ❌ | ✅ `sensor.emergency_alerts_<hub>_summary` |
+| Companion Lovelace card | ❌ | ❌ | ✅ [one-tap ack/snooze/resolve](https://github.com/issmirnov/lovelace-emergency-alerts-card) |
+
+**Use `notify:`** when you just want to *fire* a message — you already detect the condition somewhere else, and you don't need state, ack, or retries.
+
+**Use `alert:`** when YAML is fine and you want a built-in repeat-until-acknowledged loop for a single binary condition. It's stable, in-tree, and zero dependencies.
+
+**Use `emergency_alerts`** when you want any of: a real state machine you can query and dashboard, multi-condition (template/logical) triggers, severity rollups across many alerts, sustain-duration debounce, separate acknowledge / snooze / escalate signals, or no-YAML setup. The trade-off is a custom-integration dependency (HACS) versus core.
+
 ## Companion card
 
 [**lovelace-emergency-alerts-card**](https://github.com/issmirnov/lovelace-emergency-alerts-card) — a dashboard card that renders each alert with one-tap acknowledge / snooze / resolve buttons driving the `select.<alert>_state` entity this integration exposes. Install separately via HACS.

--- a/custom_components/emergency_alerts/manifest.json
+++ b/custom_components/emergency_alerts/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/issmirnov/emergency_alerts/issues",
   "requirements": [],
-  "version": "4.2.1"
+  "version": "4.2.2"
 }

--- a/custom_components/emergency_alerts/test_requirements.txt
+++ b/custom_components/emergency_alerts/test_requirements.txt
@@ -1,9 +1,14 @@
 pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
-pytest-homeassistant-custom-component>=0.13.0
+# pin pytest-homeassistant-custom-component to a version that ships HA 2026.2+
+# so OptionsFlow.config_entry is auto-bound (the integration relies on this).
+pytest-homeassistant-custom-component>=0.13.250
 pytest-xdist>=3.0.0
-homeassistant>=2024.1.0
+# True minimum: HA changed OptionsFlow.config_entry to a sealed property in
+# 2026.2 — pre-2026.2 won't bind it and self.config_entry raises AttributeError
+# inside the options flow. Match the floor in hacs.json + manifest.
+homeassistant>=2026.2.0
 freezegun>=1.2.0
 syrupy>=4.0.0
 pytz>=2023.3 

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Emergency Alerts",
   "content_in_root": false,
   "country": "US",
-  "homeassistant": "2023.1.0"
-} 
+  "homeassistant": "2026.2.0"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ force_alphabetical_sort_within_sections = true
 combine_as_imports = true
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.13"
 show_error_codes = true
 follow_imports = "silent"
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

Cleanup release. No functional changes to alert behavior — upgrade is risk-free for existing installs.

Gets PR #24 (symlink) and PR #25 (architect-gate) into a tagged version, and tackles items 1–5 from the v4.2.x post-mortem.

## What's in 4.2.2

### Fixed
- **`hacs.json` claimed HA 2023.1.0 minimum, which was a lie.** Integration uses `OptionsFlow.config_entry` as a sealed property — a feature that landed in HA 2026.2. On older HA, every options-flow step raises `AttributeError`. Floor corrected to `2026.2.0`.
- **Three "flaky" integration tests** (`test_concurrent_updates`, `test_snooze_select_updates_binary_sensor`, `test_select_mutual_exclusivity`) were not actually flaky — they were hitting the `config_entry` attribute error because `test_requirements.txt` allowed HA 2024.1.0+ and pip resolved to 2024.3.3. After pinning to `homeassistant>=2026.2.0`, **all 99 tests pass.**

### Changed
- `.gitattributes` with `export-ignore` excludes dev artifacts (`tests/`, `test_requirements.txt`, `htmlcov/`, `dev_tools/`, `e2e-tests/`, `.devcontainer/`, `Dockerfile.*`, `scripts/`, `docs/`, etc.) from release tarballs. Verified locally with `git archive --worktree-attributes` — tarball drops to ~180KB and contains only what users need.
- `Dockerfile.test` base bumped to `python:3.13-slim` (HA 2026 requires 3.13; CI was already on 3.13, this fixes the drift).
- `pyproject.toml` mypy target bumped `3.9` → `3.13`.

### Documentation
- **README: "How it compares to HA's built-in `alert:` and `notify:`"** — side-by-side comparison table covering config style, state model, triggers, ack/snooze/escalate, severity, and "when to use what".

### Bundled PRs
- #24 — dropped dangling dev symlink that broke HACS install
- #25 — Architect-Gate workflow now actually reviews diffs

## Why v4.2.2 (not 4.3.0)?

Bug fixes + accurate compatibility metadata + docs only. No new user-facing features. `for_seconds` (which would justify a minor bump) already shipped in v4.2.0.

Coming in v4.3.0 (separate work):
- Expose `logical` trigger type in the UI config flow
- Add `on_escalated_script` field for native escalation push without a wrapper automation

## Test plan

- [x] Full Docker test suite (99 passed, 0 failed, 0 errors) on the new HA-2026.2 image
- [x] `.gitattributes` verified via `git archive --worktree-attributes` — excluded paths absent, all integration code present
- [ ] CI passes (Hassfest, HACS, Backend Tests on 3.13, Lint, Architect-Gate)
- [ ] Post-merge: tag `v4.2.2`, create GitHub release, verify HACS picks it up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)