### PR TITLE
feat: on_escalated_script field — native escalation push without wrapper

### DIFF
--- a/custom_components/emergency_alerts/binary_sensor.py
+++ b/custom_components/emergency_alerts/binary_sensor.py
@@ -44,14 +44,12 @@ ESCALATION_MINUTES = 5  # Default escalation time if not specified
 SUMMARY_UPDATE_SIGNAL = "emergency_alerts_summary_update"
 
 
-def _resolve_on_triggered(alert_data):
-    """Resolve the on-trigger actions for an alert.
+def _resolve_script_field(alert_data, action_field, script_field):
+    """Resolve an action list, preferring the explicit field over a script shortcut.
 
-    Returns the explicit ``on_triggered`` action list if set, otherwise
-    synthesizes one from ``on_triggered_script`` (the field exposed by the
-    config_flow UI). Prior to this resolver, ``on_triggered_script`` was
-    stored in alert_data but never consumed by binary_sensor, so the script
-    field in the UI did nothing.
+    If ``alert_data[action_field]`` is set, return it unchanged. Otherwise,
+    if ``alert_data[script_field]`` is set, synthesize a single-entry list
+    that calls ``script.turn_on`` against the named script entity.
 
     The synthesized action emits ``entity_id`` inside ``data`` (not
     ``target``) because both ``_call_actions`` and ``_execute_action``
@@ -60,12 +58,13 @@ def _resolve_on_triggered(alert_data):
     entity to operate on. HA accepts ``entity_id`` inside ``data`` for the
     ``script.turn_on`` service (legacy format).
 
-    Output is a list of action dicts that _parse_actions can normalize.
+    Used to wire both ``on_triggered_script`` and ``on_escalated_script``
+    config-flow UI fields into the runtime action lists.
     """
-    explicit = alert_data.get("on_triggered")
+    explicit = alert_data.get(action_field)
     if explicit:
         return explicit
-    script_entity = alert_data.get("on_triggered_script")
+    script_entity = alert_data.get(script_field)
     if script_entity:
         return [
             {
@@ -74,6 +73,25 @@ def _resolve_on_triggered(alert_data):
             }
         ]
     return None
+
+
+def _resolve_on_triggered(alert_data):
+    """Resolve the on-trigger actions: explicit ``on_triggered`` or ``on_triggered_script``.
+
+    See :func:`_resolve_script_field` for the resolution rules.
+    """
+    return _resolve_script_field(alert_data, "on_triggered", "on_triggered_script")
+
+
+def _resolve_on_escalated(alert_data):
+    """Resolve the on-escalation actions: explicit ``on_escalated`` or ``on_escalated_script``.
+
+    Mirrors :func:`_resolve_on_triggered` so users can wire native escalation
+    notifications without an external wrapper automation. The
+    ``on_escalated_script`` field is exposed by the config_flow UI alongside
+    ``on_triggered_script``.
+    """
+    return _resolve_script_field(alert_data, "on_escalated", "on_escalated_script")
 
 
 def _parse_actions(action_string):
@@ -246,7 +264,9 @@ class EmergencyBinarySensor(BinarySensorEntity):
             _resolve_on_triggered(alert_data)
         )
         self._on_cleared = _parse_actions(alert_data.get("on_cleared"))
-        self._on_escalated = _parse_actions(alert_data.get("on_escalated"))
+        self._on_escalated = _parse_actions(
+            _resolve_on_escalated(alert_data)
+        )
 
         # Entity attributes
         self._attr_name = f"Emergency: {name}"

--- a/custom_components/emergency_alerts/config_flow.py
+++ b/custom_components/emergency_alerts/config_flow.py
@@ -253,6 +253,9 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
             _optional("on_triggered_script", defaults.get("on_triggered_script")): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="script")
             ),
+            _optional("on_escalated_script", defaults.get("on_escalated_script")): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="script")
+            ),
         })
 
     def _build_alert_data(self, user_input):
@@ -283,6 +286,8 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
         # Store script entity_id as string (binary sensor will build action)
         if user_input.get("on_triggered_script"):
             alert_data["on_triggered_script"] = user_input["on_triggered_script"]
+        if user_input.get("on_escalated_script"):
+            alert_data["on_escalated_script"] = user_input["on_escalated_script"]
 
         # Persist the debounce duration only if non-zero (keeps the stored
         # config tidy and matches how older alerts will load — int(...) treats

--- a/custom_components/emergency_alerts/strings.json
+++ b/custom_components/emergency_alerts/strings.json
@@ -87,7 +87,8 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
-          "on_triggered_script": "Script to Run When Triggered (optional)"
+          "on_triggered_script": "Script to Run When Triggered (optional)",
+          "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert (e.g., 'Front Door Open', 'High Temperature')",
@@ -97,7 +98,8 @@
           "trigger_state": "State that triggers the alert. Examples: 'on' for binary sensors, 'unavailable' for offline devices, '30' for numeric thresholds",
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
-          "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts."
+          "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
+          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script — point at a script.<x> entity. Useful for sending an extra/louder notification after the first one is ignored."
         }
       },
       "edit_alert": {
@@ -118,7 +120,8 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
-          "on_triggered_script": "Script to Run When Triggered (optional)"
+          "on_triggered_script": "Script to Run When Triggered (optional)",
+          "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert",
@@ -128,7 +131,8 @@
           "trigger_state": "State that triggers the alert (e.g., 'on', 'unavailable', '30')",
           "template": "Jinja2 template that returns True when alert should trigger. Test in Developer Tools > Template.",
           "for_seconds": "Alert only fires after trigger has been true for this many seconds continuously (debounce). 0 = no debounce.",
-          "on_triggered_script": "Optional script to run when this alert triggers"
+          "on_triggered_script": "Optional script to run when this alert triggers",
+          "on_escalated_script": "Optional script to run when this alert escalates (unacked past the timeout)"
         }
       },
       "remove_alert": {

--- a/custom_components/emergency_alerts/strings.json
+++ b/custom_components/emergency_alerts/strings.json
@@ -99,7 +99,7 @@
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
           "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
-          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script — point at a script.<x> entity. Useful for sending an extra/louder notification after the first one is ignored."
+          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script. Useful for sending an extra or louder notification after the first one is ignored."
         }
       },
       "edit_alert": {

--- a/custom_components/emergency_alerts/tests/test_binary_sensor.py
+++ b/custom_components/emergency_alerts/tests/test_binary_sensor.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, Mock, patch
 from homeassistant.core import HomeAssistant
 
 from custom_components.emergency_alerts.binary_sensor import (
+    _resolve_on_escalated,
+    _resolve_on_triggered,
     async_setup_entry,
     EmergencyBinarySensor,
 )
@@ -264,6 +266,73 @@ async def test_action_calls(hass: HomeAssistant, mock_template_config_entry):
         
         # Clean up escalation timer if it was started
         sensor._cleanup_timers()
+
+
+# ---------------------------------------------------------------------------
+# Resolver tests — _resolve_on_triggered and _resolve_on_escalated share the
+# same shape (explicit action list wins over script shortcut). The unit tests
+# pin the contract so a future refactor of `_resolve_script_field` doesn't
+# silently break either field.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_on_triggered_returns_none_when_neither_field_set():
+    assert _resolve_on_triggered({}) is None
+
+
+def test_resolve_on_triggered_synthesizes_script_turn_on_from_shortcut():
+    result = _resolve_on_triggered({"on_triggered_script": "script.front_door_chime"})
+    assert result == [{
+        "service": "script.turn_on",
+        "data": {"entity_id": "script.front_door_chime"},
+    }]
+
+
+def test_resolve_on_triggered_explicit_actions_take_precedence_over_shortcut():
+    explicit = [{"service": "notify.notify", "data": {"message": "hi"}}]
+    result = _resolve_on_triggered({
+        "on_triggered": explicit,
+        "on_triggered_script": "script.also_run",  # ignored
+    })
+    assert result is explicit
+
+
+def test_resolve_on_escalated_returns_none_when_neither_field_set():
+    assert _resolve_on_escalated({}) is None
+
+
+def test_resolve_on_escalated_synthesizes_script_turn_on_from_shortcut():
+    result = _resolve_on_escalated({"on_escalated_script": "script.emergency_critical_push"})
+    assert result == [{
+        "service": "script.turn_on",
+        "data": {"entity_id": "script.emergency_critical_push"},
+    }]
+
+
+def test_resolve_on_escalated_explicit_actions_take_precedence_over_shortcut():
+    explicit = [{"service": "notify.mobile_app_x", "data": {"message": "escalation!"}}]
+    result = _resolve_on_escalated({
+        "on_escalated": explicit,
+        "on_escalated_script": "script.ignored",
+    })
+    assert result is explicit
+
+
+def test_resolve_on_escalated_independent_of_on_triggered_script():
+    """Setting only on_triggered_script must NOT bleed into on_escalated.
+
+    Regression: an earlier draft factored the resolver as a single helper
+    that defaulted to the on_triggered_script field for both. The fields
+    must stay independent so users can configure a quiet initial trigger
+    and a louder escalation, or vice versa.
+    """
+    alert = {"on_triggered_script": "script.chime_only"}
+    assert _resolve_on_triggered(alert) is not None
+    assert _resolve_on_escalated(alert) is None
+
+    alert = {"on_escalated_script": "script.escalation_only"}
+    assert _resolve_on_triggered(alert) is None
+    assert _resolve_on_escalated(alert) is not None
 
 
 async def test_extra_state_attributes(hass: HomeAssistant, create_binary_sensor):

--- a/custom_components/emergency_alerts/translations/en.json
+++ b/custom_components/emergency_alerts/translations/en.json
@@ -87,7 +87,8 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
-          "on_triggered_script": "Script to Run When Triggered (optional)"
+          "on_triggered_script": "Script to Run When Triggered (optional)",
+          "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert (e.g., 'Front Door Open', 'High Temperature')",
@@ -97,7 +98,8 @@
           "trigger_state": "State that triggers the alert. Examples: 'on' for binary sensors, 'unavailable' for offline devices, '30' for numeric thresholds",
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
-          "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts."
+          "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
+          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script — point at a script.<x> entity. Useful for sending an extra/louder notification after the first one is ignored."
         }
       },
       "edit_alert": {
@@ -118,7 +120,8 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
-          "on_triggered_script": "Script to Run When Triggered (optional)"
+          "on_triggered_script": "Script to Run When Triggered (optional)",
+          "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert",
@@ -128,7 +131,8 @@
           "trigger_state": "State that triggers the alert (e.g., 'on', 'unavailable', '30')",
           "template": "Jinja2 template that returns True when alert should trigger. Test in Developer Tools > Template.",
           "for_seconds": "Alert only fires after trigger has been true for this many seconds continuously (debounce). 0 = no debounce.",
-          "on_triggered_script": "Optional script to run when this alert triggers"
+          "on_triggered_script": "Optional script to run when this alert triggers",
+          "on_escalated_script": "Optional script to run when this alert escalates (unacked past the timeout)"
         }
       },
       "remove_alert": {

--- a/custom_components/emergency_alerts/translations/en.json
+++ b/custom_components/emergency_alerts/translations/en.json
@@ -99,7 +99,7 @@
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
           "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
-          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script — point at a script.<x> entity. Useful for sending an extra/louder notification after the first one is ignored."
+          "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script. Useful for sending an extra or louder notification after the first one is ignored."
         }
       },
       "edit_alert": {


### PR DESCRIPTION
## Summary

Adds a new optional config-flow field, \`on_escalated_script\`, that mirrors the existing \`on_triggered_script\` shortcut. Point it at a \`script.<x>\` entity and the integration will call \`script.turn_on\` on that script when the escalation timer fires.

Lets users wire a louder/different notification on escalation without needing a separate HA automation to listen for \`select.<alert>_state → escalated\`.

## Background

The integration has had an \`on_escalated\` action-list field for a while but no UI shortcut. In a real install, \`on_triggered_script\` ships push-on-trigger; users who also want push-on-escalation either:
- Hand-write JSON/YAML into the \`on_escalated\` field (ugly), or
- Wire a separate HA automation (extra boilerplate; see issmirnov/emergency_alerts#23 era \`automation.emergency_critical_alert_escalated\`)

After this PR, the same one-field UX as the trigger case is available for escalation.

## Implementation

- **\`_resolve_script_field(alert_data, action_field, script_field)\`** — shared helper factored out of the old \`_resolve_on_triggered\`. Takes either field name pair and returns the explicit list or a synthesized \`script.turn_on\` call.
- **\`_resolve_on_escalated\`** — new resolver that delegates to the shared helper.
- **\`binary_sensor.__init__\`** — \`self._on_escalated\` now goes through \`_resolve_on_escalated\` so the shortcut takes effect at runtime (the field is already fired from \`_start_escalation_timer\`).
- **\`config_flow._build_alert_schema\`** — adds \`on_escalated_script\` EntitySelector(domain=script) using the existing \`_optional()\` helper (no empty-string default).
- **\`_build_alert_data\`** — persists the field to entry data when set.
- **\`strings.json\` + \`translations/en.json\`** — labels + descriptions for both add and edit forms.

## Test plan

7 new unit tests in \`test_binary_sensor.py\`:

- [x] \`_resolve_on_triggered\` / \`_resolve_on_escalated\` both return None when neither field is set
- [x] Both synthesize \`script.turn_on\` with entity_id inside \`data\` (not \`target\`) when only the shortcut is set
- [x] Explicit action list takes precedence over the shortcut
- [x] **\`test_resolve_on_escalated_independent_of_on_triggered_script\`** — regression for an early draft that incorrectly defaulted both to the trigger field. The two fields must stay independent.
- [x] Full Docker test suite: 106 passed, 0 failed.

## Compatibility

Backwards-compatible. Existing alerts without \`on_escalated_script\` set continue to use whatever's in \`on_escalated\` (or nothing). No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)