### PR TITLE
feat: expose logical trigger type in the UI config flow

### DIFF
--- a/custom_components/emergency_alerts/config_flow.py
+++ b/custom_components/emergency_alerts/config_flow.py
@@ -233,7 +233,7 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
                 "trigger_type", default=defaults.get("trigger_type", "simple")
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=["simple", "template"],
+                    options=["simple", "template", "logical"],
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
@@ -242,6 +242,21 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
                 "trigger_state", default=defaults.get("trigger_state", "on")
             ): str,
             vol.Optional("template", default=defaults.get("template", "")): selector.TemplateSelector(),
+            # Logical trigger fields. Only used when trigger_type == "logical".
+            # `logical_conditions` is a list of {entity_id, state} pairs;
+            # ObjectSelector renders it as a YAML editor and round-trips the
+            # parsed list directly into alert_data. `_parse_logical_conditions`
+            # in binary_sensor.py also accepts a JSON/YAML string, so older
+            # alerts created via the API still load fine.
+            _optional("logical_conditions", defaults.get("logical_conditions")): selector.ObjectSelector(),
+            vol.Optional(
+                "logical_operator", default=defaults.get("logical_operator", "and")
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["and", "or"],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
             # Debounce / sustain duration: alert only fires after the trigger
             # condition has been true for this many seconds continuously. 0 =
             # no debounce (fire immediately). Useful for "window open >5min",
@@ -282,6 +297,27 @@ class EmergencyOptionsFlow(config_entries.OptionsFlow):
             # Entity ID is optional for template triggers
             if user_input.get("entity_id"):
                 alert_data["entity_id"] = user_input["entity_id"]
+        elif trigger_type == "logical":
+            # logical_conditions is a list of {entity_id, state} dicts; the
+            # runtime evaluator (binary_sensor._parse_logical_conditions) is
+            # the source of truth on the schema.
+            conditions = user_input.get("logical_conditions")
+            if not conditions:
+                raise vol.Invalid(
+                    "At least one condition is required for logical triggers"
+                )
+            if not isinstance(conditions, list) or not all(
+                isinstance(c, dict) and c.get("entity_id") and c.get("state") is not None
+                for c in conditions
+            ):
+                raise vol.Invalid(
+                    "logical_conditions must be a list of "
+                    "{entity_id, state} dicts"
+                )
+            alert_data["logical_conditions"] = conditions
+            alert_data["logical_operator"] = user_input.get(
+                "logical_operator", "and"
+            )
 
         # Store script entity_id as string (binary sensor will build action)
         if user_input.get("on_triggered_script"):

--- a/custom_components/emergency_alerts/strings.json
+++ b/custom_components/emergency_alerts/strings.json
@@ -87,17 +87,21 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
+          "logical_conditions": "Logical Conditions",
+          "logical_operator": "Logical Operator",
           "on_triggered_script": "Script to Run When Triggered (optional)",
           "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert (e.g., 'Front Door Open', 'High Temperature')",
-          "trigger_type": "Simple: Monitor one entity's state. Template: Use Jinja2 for complex conditions.",
+          "trigger_type": "Simple: monitor one entity's state. Template: Jinja2 for complex conditions. Logical: combine multiple entity/state pairs with AND or OR.",
           "severity": "Critical: Urgent issues. Warning: Important but not critical. Info: General notifications.",
           "entity_id": "The Home Assistant entity to monitor (e.g., binary_sensor.front_door, sensor.temperature)",
           "trigger_state": "State that triggers the alert. Examples: 'on' for binary sensors, 'unavailable' for offline devices, '30' for numeric thresholds",
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
+          "logical_conditions": "Used when Trigger Type = Logical. A YAML list where each item has an entity_id and a state. Example:\n- entity_id: binary_sensor.front_door\n  state: 'on'\n- entity_id: binary_sensor.motion_living_room\n  state: 'on'",
+          "logical_operator": "Used when Trigger Type = Logical. 'and' (all conditions must match) or 'or' (any condition matches).",
           "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
           "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script. Useful for sending an extra or louder notification after the first one is ignored."
         }
@@ -120,17 +124,21 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
+          "logical_conditions": "Logical Conditions",
+          "logical_operator": "Logical Operator",
           "on_triggered_script": "Script to Run When Triggered (optional)",
           "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert",
-          "trigger_type": "Simple: Monitor one entity's state. Template: Use Jinja2 for complex conditions.",
+          "trigger_type": "Simple: monitor one entity's state. Template: Jinja2. Logical: combine entity/state pairs with AND/OR.",
           "severity": "Critical: Urgent issues. Warning: Important but not critical. Info: General notifications.",
           "entity_id": "The Home Assistant entity to monitor",
           "trigger_state": "State that triggers the alert (e.g., 'on', 'unavailable', '30')",
           "template": "Jinja2 template that returns True when alert should trigger. Test in Developer Tools > Template.",
           "for_seconds": "Alert only fires after trigger has been true for this many seconds continuously (debounce). 0 = no debounce.",
+          "logical_conditions": "YAML list of entity_id + state pairs (Trigger Type = Logical only).",
+          "logical_operator": "'and' (all match) or 'or' (any match). Trigger Type = Logical only.",
           "on_triggered_script": "Optional script to run when this alert triggers",
           "on_escalated_script": "Optional script to run when this alert escalates (unacked past the timeout)"
         }

--- a/custom_components/emergency_alerts/tests/test_config_flow.py
+++ b/custom_components/emergency_alerts/tests/test_config_flow.py
@@ -197,6 +197,70 @@ def test_alert_schema_preserves_existing_entity_id_via_suggested_value():
         raise AssertionError("entity_id field not found in schema")
 
 
+def test_alert_schema_accepts_logical_trigger_type():
+    """`logical` is now a selectable trigger_type — schema must accept it."""
+    schema = EmergencyOptionsFlow._build_alert_schema(None)
+    result = schema({
+        "name": "Compound Alert",
+        "severity": "critical",
+        "trigger_type": "logical",
+        "logical_operator": "and",
+        "logical_conditions": [
+            {"entity_id": "binary_sensor.front_door", "state": "on"},
+            {"entity_id": "binary_sensor.motion_living_room", "state": "on"},
+        ],
+    })
+    assert result["trigger_type"] == "logical"
+    assert result["logical_operator"] == "and"
+    assert len(result["logical_conditions"]) == 2
+
+
+def test_build_alert_data_rejects_logical_with_no_conditions():
+    """Logical trigger without conditions must raise."""
+    flow = EmergencyOptionsFlow()
+    with pytest.raises(vol.Invalid, match="At least one condition is required"):
+        flow._build_alert_data({
+            "name": "Bad Alert",
+            "severity": "warning",
+            "trigger_type": "logical",
+            "logical_operator": "and",
+        })
+
+
+def test_build_alert_data_rejects_logical_with_malformed_conditions():
+    """Conditions must be a list of dicts with entity_id + state."""
+    flow = EmergencyOptionsFlow()
+    with pytest.raises(vol.Invalid, match="must be a list of"):
+        flow._build_alert_data({
+            "name": "Bad Alert",
+            "severity": "warning",
+            "trigger_type": "logical",
+            "logical_operator": "and",
+            "logical_conditions": [{"entity_id": "binary_sensor.x"}],  # missing 'state'
+        })
+
+
+def test_build_alert_data_persists_logical_fields():
+    """Happy path: a valid logical alert serializes both fields into storage."""
+    flow = EmergencyOptionsFlow()
+    data = flow._build_alert_data({
+        "name": "Front Door And Motion",
+        "severity": "critical",
+        "trigger_type": "logical",
+        "logical_operator": "or",
+        "logical_conditions": [
+            {"entity_id": "binary_sensor.front_door", "state": "on"},
+            {"entity_id": "binary_sensor.motion_living_room", "state": "on"},
+        ],
+    })
+    assert data["trigger_type"] == "logical"
+    assert data["logical_operator"] == "or"
+    assert len(data["logical_conditions"]) == 2
+    # No stray simple/template fields
+    assert "entity_id" not in data
+    assert "template" not in data
+
+
 # ---------------------------------------------------------------------------
 # Edit-alert flow regression — submitting an edit_alert_form rendered with
 # step_id="add_alert" used to misfire as "already_configured" because the

--- a/custom_components/emergency_alerts/translations/en.json
+++ b/custom_components/emergency_alerts/translations/en.json
@@ -87,17 +87,21 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
+          "logical_conditions": "Logical Conditions",
+          "logical_operator": "Logical Operator",
           "on_triggered_script": "Script to Run When Triggered (optional)",
           "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert (e.g., 'Front Door Open', 'High Temperature')",
-          "trigger_type": "Simple: Monitor one entity's state. Template: Use Jinja2 for complex conditions.",
+          "trigger_type": "Simple: monitor one entity's state. Template: Jinja2 for complex conditions. Logical: combine multiple entity/state pairs with AND or OR.",
           "severity": "Critical: Urgent issues. Warning: Important but not critical. Info: General notifications.",
           "entity_id": "The Home Assistant entity to monitor (e.g., binary_sensor.front_door, sensor.temperature)",
           "trigger_state": "State that triggers the alert. Examples: 'on' for binary sensors, 'unavailable' for offline devices, '30' for numeric thresholds",
           "template": "Jinja2 template that returns True when alert should trigger. Example: states('sensor.temperature')|float > 25 would return True when temperature exceeds 25. Test templates in Developer Tools > Template before using.",
           "for_seconds": "Alert only fires after the trigger has been true for this many seconds continuously (debounce). 0 = no debounce. Useful for 'window open >5min', 'garage open too long', 'leak sensor on >10s to avoid false positives'.",
+          "logical_conditions": "Used when Trigger Type = Logical. A YAML list where each item has an entity_id and a state. Example:\n- entity_id: binary_sensor.front_door\n  state: 'on'\n- entity_id: binary_sensor.motion_living_room\n  state: 'on'",
+          "logical_operator": "Used when Trigger Type = Logical. 'and' (all conditions must match) or 'or' (any condition matches).",
           "on_triggered_script": "Optional script to run when this alert triggers. Create scripts in Settings > Automations & Scenes > Scripts.",
           "on_escalated_script": "Optional script to run when this alert escalates (unacknowledged past the escalation timeout). Same pattern as on_triggered_script. Useful for sending an extra or louder notification after the first one is ignored."
         }
@@ -120,17 +124,21 @@
           "trigger_state": "Trigger State",
           "template": "Jinja2 Template",
           "for_seconds": "Sustain Duration (seconds)",
+          "logical_conditions": "Logical Conditions",
+          "logical_operator": "Logical Operator",
           "on_triggered_script": "Script to Run When Triggered (optional)",
           "on_escalated_script": "Script to Run When Escalated (optional)"
         },
         "data_description": {
           "name": "A descriptive name for this alert",
-          "trigger_type": "Simple: Monitor one entity's state. Template: Use Jinja2 for complex conditions.",
+          "trigger_type": "Simple: monitor one entity's state. Template: Jinja2. Logical: combine entity/state pairs with AND/OR.",
           "severity": "Critical: Urgent issues. Warning: Important but not critical. Info: General notifications.",
           "entity_id": "The Home Assistant entity to monitor",
           "trigger_state": "State that triggers the alert (e.g., 'on', 'unavailable', '30')",
           "template": "Jinja2 template that returns True when alert should trigger. Test in Developer Tools > Template.",
           "for_seconds": "Alert only fires after trigger has been true for this many seconds continuously (debounce). 0 = no debounce.",
+          "logical_conditions": "YAML list of entity_id + state pairs (Trigger Type = Logical only).",
+          "logical_operator": "'and' (all match) or 'or' (any match). Trigger Type = Logical only.",
           "on_triggered_script": "Optional script to run when this alert triggers",
           "on_escalated_script": "Optional script to run when this alert escalates (unacked past the timeout)"
         }


### PR DESCRIPTION
## Summary

The integration's evaluator has supported the \`logical\` trigger type for ages — combining N \`{entity_id, state}\` pairs with AND or OR — but the config flow only offered \`simple\` and \`template\`. Users had to write to \`.storage\` or call the REST API to create logical alerts. Now they're first-class in the add/edit UI.

The translation key for \`logical\` was already in \`strings.json\` (\`"logical: Combine multiple entity conditions"\`), but the schema didn't list it as an option. This PR wires it through.

## Schema additions

In \`_build_alert_schema\`:

- **\`trigger_type\`** SelectSelector — added \`logical\` to the options list.
- **\`logical_conditions\`** — \`ObjectSelector\`. Renders as an inline YAML editor in HA's UI; round-trips a Python list straight into alert_data. Compatible with the existing \`_parse_logical_conditions\` parser in binary_sensor.py which also accepts JSON/YAML strings (so API-created alerts still load fine).
- **\`logical_operator\`** — SelectSelector with \`and\` / \`or\`, default \`and\`.

## Validation

\`_build_alert_data\` now requires:
- At least one condition
- Each condition is a dict with both \`entity_id\` and \`state\`

## Example user input

\`\`\`yaml
- entity_id: binary_sensor.front_door
  state: 'on'
- entity_id: binary_sensor.motion_living_room
  state: 'on'
\`\`\`

With \`logical_operator: and\` → alert fires only when **both** are on. With \`or\` → fires when **either** is on.

## Test plan

4 new tests in \`test_config_flow.py\`:
- [x] \`test_alert_schema_accepts_logical_trigger_type\` — schema parses a full logical submission
- [x] \`test_build_alert_data_rejects_logical_with_no_conditions\` — required-field check
- [x] \`test_build_alert_data_rejects_logical_with_malformed_conditions\` — each condition must have entity_id + state
- [x] \`test_build_alert_data_persists_logical_fields\` — happy path: only logical fields make it into storage
- [x] Full Docker suite: 103 passed (was 99 before this PR + #27)

## Compatibility

Backwards-compatible. Existing alerts with trigger_type in {simple, template} are unaffected. Alerts that already have \`logical_conditions\` stored (via API) load identically — the parser was already there, only the UI surface is new.

## Note on overlap with #27

Both this PR and #27 (\`on_escalated_script\`) touch \`config_flow.py\` and the translation files. The diffs are mechanical (each adds different fields to the same schema). Merge order: #27 first (smaller, narrower), then rebase this on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)