### PR TITLE
feat: v4.4.0 — clean entity naming + severity-aware state machine

### DIFF
--- a/custom_components/emergency_alerts/binary_sensor.py
+++ b/custom_components/emergency_alerts/binary_sensor.py
@@ -268,21 +268,23 @@ class EmergencyBinarySensor(BinarySensorEntity):
             _resolve_on_escalated(alert_data)
         )
 
-        # Entity attributes
-        self._attr_name = f"Emergency: {name}"
+        # Modern HA naming: the device carries the full label, the entity has
+        # no name of its own. HA frontends render friendly_name as just
+        # `device.name`, eliminating the `<device> <entity>` doubling that
+        # earlier releases worked around with name_by_user overrides.
+        self._attr_has_entity_name = True
+        self._attr_name = None
         self._attr_unique_id = f"emergency_{hub_name}_{alert_id}"
-        # Force a clean entity_id on first registration. Without this, HA
-        # would slugify-combine device.name + entity._attr_name and produce
-        # binary_sensor.emergency_alert_<name>_emergency_<name>. Setting
-        # entity_id directly is the documented way to hint a specific
-        # object_id (HA's entity_platform reads this into
-        # internal_integration_suggested_object_id during async_added_to_hass).
-        # Existing alerts in the entity_registry keep their stored entity_id;
-        # this only affects new alerts.
+        # Pin a clean entity_id on first registration. With has_entity_name=True
+        # and _attr_name=None, HA derives object_id from the device name —
+        # which would be e.g. `binary_sensor.living_room_humidity`, dropping
+        # the `emergency_` namespace prefix. Set entity_id explicitly so the
+        # ID still encodes that this is an emergency_alerts entity. Existing
+        # alerts in the entity_registry keep their stored entity_id.
         self.entity_id = f"binary_sensor.emergency_{alert_id}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, f"alert_{entry.entry_id}_{alert_id}")},
-            "name": f"Emergency Alert: {name}",
+            "name": name,
             "manufacturer": "Emergency Alerts",
             "model": f"{self._severity.title()} Alert",
             "sw_version": "1.0",
@@ -809,7 +811,16 @@ class EmergencyBinarySensor(BinarySensorEntity):
             self._pending_trigger_unsub = None
 
     async def _start_escalation_timer(self):
-        """Start escalation timer (called by switches when un-acknowledging)."""
+        """Start escalation timer (called by switches when un-acknowledging).
+
+        Info-severity alerts are ambient — they auto-clear when the underlying
+        trigger condition flips. Escalating to a louder state makes no sense
+        for them, so we skip the timer entirely. Warning/critical keep the
+        full timer behavior.
+        """
+        if self._severity == "info":
+            return
+
         remind_after = self._get_escalation_time()
         if remind_after is None or remind_after <= 0:
             return

--- a/custom_components/emergency_alerts/select.py
+++ b/custom_components/emergency_alerts/select.py
@@ -28,17 +28,25 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Available states for the select entity. Includes INACTIVE and ESCALATED so the
-# select widget can display a meaningful current value when the alert is not
-# firing (INACTIVE) or has escalated past its ack window (ESCALATED). Previously
-# the sync logic set _attr_current_option to STATE_INACTIVE when the alert was
-# off, but since "inactive" wasn't in this list, the select rendered "unknown".
+# Full state set for warning/critical alerts. Includes INACTIVE so the select
+# widget can render a meaningful "off" value when the alert isn't firing.
 ALERT_STATES = [
     STATE_INACTIVE,
     STATE_ACTIVE,
     STATE_ACKNOWLEDGED,
     STATE_SNOOZED,
     STATE_ESCALATED,
+    STATE_RESOLVED,
+]
+
+# Info-severity alerts are ambient: they auto-clear when the trigger condition
+# flips, so snooze and escalation make no sense. They keep acknowledge +
+# resolve so the user can dismiss a notification they don't care to leave on
+# the dashboard.
+INFO_ALERT_STATES = [
+    STATE_INACTIVE,
+    STATE_ACTIVE,
+    STATE_ACKNOWLEDGED,
     STATE_RESOLVED,
 ]
 
@@ -76,25 +84,27 @@ class EmergencyAlertStateSelect(SelectEntity):
         self._entry = entry
         self._alert_id = alert_id
         self._alert_data = alert_data
-        self._attr_options = ALERT_STATES
+        # Severity decides the option set: info alerts are ambient (no snooze,
+        # no escalation), warning/critical use the full state machine.
+        self._severity = alert_data.get("severity", "warning")
+        self._attr_options = (
+            INFO_ALERT_STATES if self._severity == "info" else ALERT_STATES
+        )
         self._attr_current_option = STATE_ACTIVE
         self._snooze_task = None
 
-        # Naming
-        alert_name = alert_data.get("name", alert_id)
-        self._attr_name = f"{alert_name} State"
+        # Modern HA naming: device carries the alert's display name, the select
+        # entity is just the "State" surface on that device. HA renders this as
+        # `<Alert Name> State` automatically.
+        self._attr_has_entity_name = True
+        self._attr_name = "State"
         self._attr_unique_id = f"{entry.entry_id}_{alert_id}_state"
-        # Force a clean entity_id on first registration. Without this, HA
-        # would slugify-combine device.name + entity._attr_name and produce
-        # select.emergency_alert_<name>_<name>_state. Setting entity_id
-        # directly is the documented way to hint a specific object_id (HA's
-        # entity_platform reads this into internal_integration_suggested_object_id
-        # during async_added_to_hass). Existing selects in the entity_registry
-        # keep their stored entity_id; this only affects new alerts.
+        # Pin entity_id explicitly so it stays `select.<alert>_state` rather
+        # than being derived from device.name + entity._attr_name.
         self.entity_id = f"select.{alert_id}_state"
         self._attr_icon = "mdi:state-machine"
 
-        # Device info - link to alert device
+        # Device info - link to alert device (name comes from binary_sensor)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"alert_{entry.entry_id}_{alert_id}")},
         )

--- a/custom_components/emergency_alerts/sensor.py
+++ b/custom_components/emergency_alerts/sensor.py
@@ -51,6 +51,8 @@ class EmergencyGlobalSummarySensor(SensorEntity):
 
     def __init__(self, hass):
         self.hass = hass
+        # Global summary isn't tied to a hub device, so it doesn't get the
+        # has_entity_name treatment — friendly_name is exactly this string.
         self._attr_name = "Emergency Alerts Summary"
         self._attr_unique_id = "emergency_alerts_global_summary"
         self._attr_icon = "mdi:alert-circle"
@@ -111,20 +113,22 @@ class EmergencyHubSensor(SensorEntity):
         self._active_alerts: list[str] = []
         self._unsub = None
 
-        self._attr_name = f"Emergency Alerts {group_name.title()} Summary"
+        # Modern HA naming: the hub device carries the group name as its
+        # label; this sensor is just the "Summary" surface on that device.
+        # Frontend renders as e.g. "Thermo Summary" instead of the old
+        # doubled "Emergency Alerts - Thermo Emergency Alerts Thermo Summary".
+        self._attr_has_entity_name = True
+        self._attr_name = "Summary"
         self._attr_unique_id = f"emergency_alerts_hub_{hub_name}"
         self._attr_icon = "mdi:view-dashboard"
-        # Force clean entity_id. Without this, device.name + entity._attr_name
-        # would combine into sensor.emergency_alerts_<group>_emergency_alerts_<group>_summary.
-        # Use group (lowercased) so the entity_id matches the user-facing hub
-        # name from config_flow rather than the internal hub_name slug.
-        # See note in binary_sensor.py.
+        # Pin entity_id so it stays `sensor.emergency_alerts_<group>_summary`.
         self.entity_id = f"sensor.emergency_alerts_{group_name.lower()}_summary"
 
-        # This sensor represents the hub device itself
+        custom = entry.data.get("custom_name")
+        device_name = group_name.title() + (f" ({custom})" if custom else "")
         self._attr_device_info = {
             "identifiers": {(DOMAIN, f"hub_{entry.entry_id}")},
-            "name": f"Emergency Alerts - {group_name.title()}" + (f" ({entry.data.get('custom_name')})" if entry.data.get("custom_name") else ""),
+            "name": device_name,
             "manufacturer": "Emergency Alerts",
             "model": f"{group_name.title()} Hub",
             "sw_version": "1.0",

--- a/custom_components/emergency_alerts/switch.py
+++ b/custom_components/emergency_alerts/switch.py
@@ -71,12 +71,13 @@ class BaseEmergencyAlertSwitch(SwitchEntity):
         self._switch_type = switch_type
         self._attr_is_on = False
 
-        # Naming
-        alert_name = alert_data.get("name", alert_id)
-        self._attr_name = f"{alert_name} {switch_name}"
+        # Modern HA naming: device carries the alert name; switch is just the
+        # `<switch_name>` surface (Acknowledge / Snooze / Resolve) on it.
+        self._attr_has_entity_name = True
+        self._attr_name = switch_name
         self._attr_unique_id = f"{entry.entry_id}_{alert_id}_{switch_type}"
 
-        # Device info - link to alert device
+        # Device info - link to alert device (name comes from binary_sensor)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"alert_{entry.entry_id}_{alert_id}")},
         )

--- a/custom_components/emergency_alerts/tests/integration/test_switch_binary_sensor_integration.py
+++ b/custom_components/emergency_alerts/tests/integration/test_switch_binary_sensor_integration.py
@@ -145,3 +145,69 @@ async def test_select_mutual_exclusivity(hass: HomeAssistant, init_group_hub):
     binary_state = hass.states.get(binary_sensor_id)
     assert binary_state.attributes.get("acknowledged") is False
     assert binary_state.attributes.get("snoozed") is True
+
+
+# ---------------------------------------------------------------------------
+# v4.4.0: severity-aware select options + modern naming.
+# ---------------------------------------------------------------------------
+
+
+from custom_components.emergency_alerts.select import (
+    ALERT_STATES,
+    INFO_ALERT_STATES,
+    EmergencyAlertStateSelect,
+)
+
+
+def _build_select(hass, severity: str = "warning"):
+    """Build an EmergencyAlertStateSelect for naming/options tests."""
+    from unittest.mock import MagicMock
+    entry = MagicMock()
+    entry.entry_id = "stub_entry"
+    return EmergencyAlertStateSelect(
+        hass=hass,
+        entry=entry,
+        alert_id="dishwasher_done",
+        alert_data={"name": "Dishwasher Done", "severity": severity},
+    )
+
+
+def test_v4_4_select_uses_has_entity_name_with_status_suffix(hass):
+    """Select friendly_name renders as `<Alert Name> State` via has_entity_name."""
+    s = _build_select(hass)
+    assert s._attr_has_entity_name is True
+    assert s._attr_name == "State"
+    # No leading prefix in the suffix.
+    assert "Emergency:" not in s._attr_name
+
+
+def test_v4_4_select_options_full_state_machine_for_warning(hass):
+    """Warning alerts get the full option list (includes snoozed, escalated)."""
+    s = _build_select(hass, severity="warning")
+    assert s._attr_options == ALERT_STATES
+    assert "snoozed" in s._attr_options
+    assert "escalated" in s._attr_options
+
+
+def test_v4_4_select_options_full_state_machine_for_critical(hass):
+    """Critical severity behaves identically to warning."""
+    s = _build_select(hass, severity="critical")
+    assert s._attr_options == ALERT_STATES
+
+
+def test_v4_4_select_options_ambient_for_info(hass):
+    """Info alerts drop snoozed + escalated; keep ack + resolve."""
+    s = _build_select(hass, severity="info")
+    assert s._attr_options == INFO_ALERT_STATES
+    assert "snoozed" not in s._attr_options, \
+        "info alerts must not allow snooze (they auto-clear)"
+    assert "escalated" not in s._attr_options, \
+        "info alerts must not allow escalation (no on_escalated action target)"
+    # But ack + resolve remain so users can dismiss a card they don't care about.
+    assert "acknowledged" in s._attr_options
+    assert "resolved" in s._attr_options
+
+
+def test_v4_4_info_states_is_strict_subset_of_full_states():
+    """INFO_ALERT_STATES must not introduce any state outside the full set."""
+    assert set(INFO_ALERT_STATES).issubset(set(ALERT_STATES))

--- a/custom_components/emergency_alerts/tests/test_binary_sensor.py
+++ b/custom_components/emergency_alerts/tests/test_binary_sensor.py
@@ -29,7 +29,11 @@ async def test_simple_trigger_setup(hass: HomeAssistant, mock_config_entry):
 
     sensor = sensors[0]
     assert isinstance(sensor, EmergencyBinarySensor)
-    assert sensor._attr_name == "Emergency: Test Alert"
+    # v4.4.0: device.name carries the alert label, _attr_name is None so HA
+    # renders friendly_name as just the device name (no "Emergency:" prefix).
+    assert sensor._attr_name is None
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_device_info["name"] == "Test Alert"
     assert sensor._trigger_type == "simple"
     assert sensor._entity_id == "binary_sensor.test_sensor"
     assert sensor._trigger_state == "on"
@@ -359,3 +363,83 @@ async def test_extra_state_attributes(hass: HomeAssistant, create_binary_sensor)
     # Check severity and group are present
     assert attrs["severity"] == "warning"
     assert attrs["group"] == "security"
+
+
+# ---------------------------------------------------------------------------
+# v4.4.0: modern entity naming + severity-aware state machine.
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor(hass, severity: str = "warning"):
+    """Build an EmergencyBinarySensor with a given severity for naming tests."""
+    from unittest.mock import MagicMock
+    from custom_components.emergency_alerts.binary_sensor import EmergencyBinarySensor
+    entry = MagicMock()
+    entry.entry_id = "stub_entry"
+    entry.data = {"hub_name": "test_hub"}
+    return EmergencyBinarySensor(
+        hass=hass, entry=entry, alert_id="dishwasher_done",
+        alert_data={
+            "name": "Dishwasher Done",
+            "trigger_type": "simple",
+            "entity_id": "binary_sensor.dishwasher_running",
+            "trigger_state": "off",
+            "severity": severity,
+        },
+        group="appliances", hub_name="test_hub",
+    )
+
+
+async def test_v4_4_naming_uses_has_entity_name_with_none_name(hass: HomeAssistant):
+    """v4.4.0: friendly_name renders as just device.name, no Emergency prefix."""
+    s = _make_sensor(hass)
+    assert s._attr_has_entity_name is True, "has_entity_name must be True"
+    assert s._attr_name is None, "_attr_name must be None so HA renders only device.name"
+    # Device name carries the alert label — no 'Emergency Alert: ' prefix.
+    assert s._attr_device_info["name"] == "Dishwasher Done"
+
+
+async def test_v4_4_device_name_has_no_legacy_prefix(hass: HomeAssistant):
+    """No code path should reintroduce the 'Emergency Alert: ' device prefix."""
+    s = _make_sensor(hass)
+    assert "Emergency Alert:" not in s._attr_device_info["name"]
+    assert "Emergency:" not in (s._attr_device_info.get("name") or "")
+
+
+async def test_v4_4_escalation_timer_skipped_for_info_severity(hass: HomeAssistant):
+    """Info-severity alerts must not arm the escalation timer."""
+    s = _make_sensor(hass, severity="info")
+    s.hass = hass
+
+    await s._start_escalation_timer()
+    assert s._escalation_task is None, \
+        "info alerts must not arm the escalation timer"
+
+
+async def test_v4_4_escalation_timer_still_arms_for_warning(hass: HomeAssistant):
+    """Warning alerts (and critical) must still arm the escalation timer."""
+    s = _make_sensor(hass, severity="warning")
+    s.hass = hass
+    # Skip the early-return on remind_after=None by setting a non-zero time.
+    s._remind_after_seconds = 300
+
+    await s._start_escalation_timer()
+    assert s._escalation_task is not None, \
+        "warning alerts must arm the escalation timer"
+    # Cleanup
+    if s._escalation_task:
+        s._escalation_task()
+        s._escalation_task = None
+
+
+async def test_v4_4_escalation_timer_still_arms_for_critical(hass: HomeAssistant):
+    """Critical severity is treated identically to warning here."""
+    s = _make_sensor(hass, severity="critical")
+    s.hass = hass
+    s._remind_after_seconds = 300
+
+    await s._start_escalation_timer()
+    assert s._escalation_task is not None
+    if s._escalation_task:
+        s._escalation_task()
+        s._escalation_task = None

--- a/custom_components/emergency_alerts/tests/test_switch.py
+++ b/custom_components/emergency_alerts/tests/test_switch.py
@@ -110,7 +110,7 @@ async def test_acknowledge_switch_initialization(hass: HomeAssistant, mock_confi
     )
 
     assert switch._switch_type == SWITCH_TYPE_ACKNOWLEDGE
-    assert switch._attr_name == "Test Alert Acknowledged"
+    assert switch._attr_name == "Acknowledged"  # v4.4.0: short suffix; full label via device + has_entity_name
     assert switch._attr_unique_id == "test_entry_123_test_alert_acknowledged"
     assert switch._attr_icon == "mdi:check-circle-outline"
     assert switch._attr_is_on is False
@@ -178,7 +178,7 @@ async def test_snooze_switch_initialization(hass: HomeAssistant, mock_config_ent
     switch.entity_id = "switch.emergency_test_alert_snoozed"
 
     assert switch._switch_type == SWITCH_TYPE_SNOOZE
-    assert switch._attr_name == "Test Alert Snoozed"
+    assert switch._attr_name == "Snoozed"  # v4.4.0
     assert switch._attr_unique_id == "test_entry_123_test_alert_snoozed"
     assert switch._attr_icon == "mdi:bell-sleep"
     assert switch._attr_is_on is False
@@ -273,7 +273,7 @@ async def test_resolve_switch_initialization(hass: HomeAssistant, mock_config_en
     switch.entity_id = "switch.emergency_test_alert_resolved"
 
     assert switch._switch_type == SWITCH_TYPE_RESOLVE
-    assert switch._attr_name == "Test Alert Resolved"
+    assert switch._attr_name == "Resolved"  # v4.4.0
     assert switch._attr_unique_id == "test_entry_123_test_alert_resolved"
     assert switch._attr_icon == "mdi:check-circle"
     assert switch._attr_is_on is False


### PR DESCRIPTION
## Summary

Two coupled fixes that finally kill the doubled "Emergency Alert: X Emergency: X" labels that have plagued the card since release, plus align the alert state machine with severity.

## The doubling bug

HA renders \`friendly_name\` from \`device.name + entity._attr_name\` whenever \`device.name_by_user\` is set. The integration was producing this:

| Source | Value |
|---|---|
| \`device.name\` (in device_info) | \`"Emergency Alert: Dishwasher Done"\` |
| \`device.name_by_user\` (rename pass) | \`"Dishwasher Done"\` |
| \`entity._attr_name\` | \`"Emergency: Dishwasher Done"\` |
| **Resulting \`friendly_name\`** | **\`"Dishwasher Done Emergency: Dishwasher Done"\`** |

The post-creation \`name_by_user\` rename pass *introduced* the doubling rather than fixing it. No amount of renaming gets out of this.

## The fix — modern HA pattern

Every entity now uses \`_attr_has_entity_name = True\` with a short suffix (or \`None\`):

| Platform | _attr_name | Device.name | Rendered friendly_name |
|---|---|---|---|
| binary_sensor | \`None\` | \`"Dishwasher Done"\` | \`"Dishwasher Done"\` |
| select | \`"State"\` | (same device) | \`"Dishwasher Done State"\` |
| sensor (hub) | \`"Summary"\` | \`"Thermo"\` | \`"Thermo Summary"\` |
| switch (deprecated) | \`switch_name\` | (alert device) | \`"Dishwasher Done Acknowledged"\` |

Old \`name_by_user\` overrides still win (HA's general policy), so anywhere users have already custom-named a device, that label persists.

## State machine — info severity is ambient

Info-severity alerts now skip escalation and drop snooze from their select options. They keep acknowledge + resolve so users can dismiss a card.

- \`binary_sensor._start_escalation_timer\`: early-returns when \`severity == "info"\`
- \`select\`: uses new \`INFO_ALERT_STATES = [inactive, active, acknowledged, resolved]\` when alert severity is info; \`ALERT_STATES\` (full) otherwise

Warning + critical unchanged.

## Tests

**120 passed** (was 110). 10 new tests cover the v4.4.0 contract:

- has_entity_name=True on every entity platform
- device.name carries no legacy prefix
- escalation timer is a no-op for info severity, still arms for warning + critical
- select option list adapts to severity
- INFO_ALERT_STATES is a strict subset of ALERT_STATES (regression guard)

Old tests that asserted \`_attr_name == "Emergency: <X>"\` updated to the new shape.

## Companion PRs

- Card update: issmirnov/lovelace-emergency-alerts-card#7 — hides snooze button and ⚠️ badge for info alerts
- Migration script for existing installs: \`scripts/migrate_v4_4_clean_names.py\` in the hassio repo (one-shot, idempotent, strips \`"Emergency Alert: "\` from device.name)

## Test plan

- [x] Full Docker test suite: 120 passed
- [x] No regressions in existing 110 tests
- [ ] CI green (Hassfest, HACS, Lint, Architect-Gate)
- [ ] Post-merge: cut v4.4.0 tag, run migration script on live HA, verify cards display clean single-label names

🤖 Generated with [Claude Code](https://claude.com/claude-code)